### PR TITLE
feat: Storybook args/controls + Vitest testing infrastructure

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
     '@storybook/addon-docs',
     '@storybook/addon-a11y',
     '@storybook/addon-themes',
+    '@storybook/addon-vitest'
   ],
   framework: '@storybook/react-vite',
 }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,7 +15,7 @@ const preview: Preview = {
       },
     },
     a11y: {
-      test: 'todo',
+      test: 'error',
     },
   },
 }

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,0 +1,14 @@
+import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview'
+import * as reactAnnotations from '@storybook/react/entry-preview'
+import * as previewAnnotations from './preview'
+import { setProjectAnnotations } from 'storybook/preview-api'
+
+const annotations = setProjectAnnotations([
+  reactAnnotations,
+  previewAnnotations,
+  a11yAddonAnnotations,
+])
+
+// Make annotations available globally for the Vitest addon's test-utils
+// This is needed for classic CSF3 stories (non-factory format)
+globalThis.globalProjectAnnotations = annotations

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@storybook/addon-a11y": "^10.2.8",
         "@storybook/addon-docs": "^10.2.8",
         "@storybook/addon-themes": "^10.2.8",
+        "@storybook/addon-vitest": "^10.2.16",
         "@storybook/react-vite": "^10.2.8",
         "@tailwindcss/postcss": "^4.1.14",
         "@testing-library/jest-dom": "^6.9.1",
@@ -31,6 +32,8 @@
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.3",
+        "@vitest/browser-playwright": "^4.0.18",
+        "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -290,9 +293,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -324,13 +327,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -416,17 +419,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1558,6 +1571,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -2788,6 +2808,42 @@
         "storybook": "^10.2.8"
       }
     },
+    "node_modules/@storybook/addon-vitest": {
+      "version": "10.2.16",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.2.16.tgz",
+      "integrity": "sha512-ApGn2Oh5qaD+Ic2gGQXE5NDkisT5Zph6HUESgaZWv52+za4JXhDAaEfVL10ZPLEMZTKihizcQaa7A0lYQ0jM3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "^3.0.0 || ^4.0.0",
+        "@vitest/browser-playwright": "^4.0.0",
+        "@vitest/runner": "^3.0.0 || ^4.0.0",
+        "storybook": "^10.2.16",
+        "vitest": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/runner": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/builder-vite": {
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.2.8.tgz",
@@ -3722,6 +3778,168 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/browser": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.0.18.tgz",
+      "integrity": "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/mocker": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pixelmatch": "7.1.0",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.0.3",
+        "ws": "^8.18.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.18"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.0.18.tgz",
+      "integrity": "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/browser-playwright/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -4216,6 +4434,35 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -5437,6 +5684,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5635,6 +5889,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "4.2.3",
@@ -6155,6 +6448,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -6272,6 +6606,16 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -6548,6 +6892,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
+      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -6605,6 +6962,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -7122,6 +7489,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7164,9 +7546,9 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "10.2.8",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.2.8.tgz",
-      "integrity": "sha512-885uSIn8NQw2ZG7vy84K45lHCOSyz1DVsDV8pHiHQj3J0riCuWLNeO50lK9z98zE8kjhgTtxAAkMTy5nkmNRKQ==",
+      "version": "10.2.16",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.2.16.tgz",
+      "integrity": "sha512-Az1Qro0XjCBttsuO55H2aIGPYqGx00T8O3o29rLQswOyZhgAVY9H2EnJiVsfmSG1Kwt8qYTVv7VxzLlqDxropA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7462,6 +7844,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "version:minor": "npm version minor",
     "version:major": "npm version major",
     "release": "npm run build:lib && npm publish --access public",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "test-storybook": "vitest --run --project=storybook",
+    "test:unit": "vitest --run --project=unit"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
@@ -75,6 +77,7 @@
     "@storybook/addon-a11y": "^10.2.8",
     "@storybook/addon-docs": "^10.2.8",
     "@storybook/addon-themes": "^10.2.8",
+    "@storybook/addon-vitest": "^10.2.16",
     "@storybook/react-vite": "^10.2.8",
     "@tailwindcss/postcss": "^4.1.14",
     "@testing-library/jest-dom": "^6.9.1",
@@ -83,6 +86,8 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",
+    "@vitest/browser-playwright": "^4.0.18",
+    "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, userEvent, within } from 'storybook/test'
 import { ButtonWidget } from './ButtonWidget'
 import { ButtonArrayLayout } from './ButtonArrayLayout'
 
@@ -7,6 +8,11 @@ const meta = {
   component: ButtonWidget,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    style: { control: 'select', options: ['SOLID', 'OUTLINE', 'GHOST', 'LINK'] },
+    color: { control: 'text' },
+    size: { control: 'select', options: ['SMALL', 'STANDARD', 'MEDIUM', 'LARGE'] },
+  },
 } satisfies Meta<typeof ButtonWidget>
 
 export default meta
@@ -17,6 +23,15 @@ export const Default: Story = {
     label: 'Submit',
     style: 'SOLID',
     color: 'ACCENT',
+    size: 'STANDARD',
+    saveInto: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+    const button = canvas.getByRole('button', { name: 'Submit' })
+    await expect(button).toBeVisible()
+    await userEvent.click(button)
+    await expect(args.saveInto).toHaveBeenCalledOnce()
   },
 }
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -6,6 +6,15 @@ const meta = {
   component: CardLayout,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    shape: { control: 'select', options: ['SQUARED', 'SEMI_ROUNDED', 'ROUNDED'] },
+    padding: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+    style: { control: 'select', options: ['NONE', 'ACCENT', 'SUCCESS', 'WARN', 'ERROR', 'INFO', 'CHARCOAL_SCHEME'] },
+    decorativeBarPosition: { control: 'select', options: ['TOP', 'START'] },
+    decorativeBarColor: { control: 'select', options: ['ACCENT', 'SUCCESS', 'WARN', 'ERROR', 'INFO'] },
+    marginAbove: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+    marginBelow: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+  },
 } satisfies Meta<typeof CardLayout>
 
 export default meta

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from 'storybook/test'
 import { useState } from 'react'
 import { CheckboxField } from './CheckboxField'
 
@@ -7,6 +8,13 @@ const meta = {
   component: CheckboxField,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+    choiceLayout: { control: 'select', options: ['STACKED', 'COMPACT'] },
+    choiceStyle: { control: 'select', options: ['STANDARD', 'CARDS'] },
+    choicePosition: { control: 'select', options: ['START', 'END'] },
+    spacing: { control: 'select', options: ['STANDARD', 'MORE', 'EVEN_MORE'] },
+  },
 } satisfies Meta<typeof CheckboxField>
 
 export default meta
@@ -19,6 +27,19 @@ export const Default: Story = {
     choiceLabels: ['English', 'Spanish', 'French', 'German'],
     choiceValues: ['en_US', 'es_ES', 'fr_FR', 'de_DE'],
     value: ['en_US', 'fr_FR'],
+  },
+  render: (args) => {
+    const [value, setValue] = useState<string[]>(args.value ?? [])
+    return <CheckboxField {...args} value={value} saveInto={setValue} />
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const englishCheckbox = canvas.getByLabelText('English')
+    const spanishCheckbox = canvas.getByLabelText('Spanish')
+    await expect(englishCheckbox).toBeChecked()
+    await expect(spanishCheckbox).not.toBeChecked()
+    await userEvent.click(spanishCheckbox)
+    await expect(spanishCheckbox).toBeChecked()
   },
 }
 
@@ -88,34 +109,12 @@ export const Disabled: Story = {
 
 export const SpacingVariations: Story = {
   args: {
+    label: 'Standard Spacing',
     choiceLabels: ['Item 1', 'Item 2', 'Item 3'],
     choiceValues: ['1', '2', '3'],
+    value: [],
+    spacing: 'STANDARD',
   },
-  render: () => (
-    <div className="space-y-6">
-      <CheckboxField
-        label="Standard Spacing"
-        choiceLabels={['Item 1', 'Item 2', 'Item 3']}
-        choiceValues={['1', '2', '3']}
-        value={[]}
-        spacing="STANDARD"
-      />
-      <CheckboxField
-        label="More Spacing"
-        choiceLabels={['Item 1', 'Item 2', 'Item 3']}
-        choiceValues={['1', '2', '3']}
-        value={[]}
-        spacing="MORE"
-      />
-      <CheckboxField
-        label="Even More Spacing"
-        choiceLabels={['Item 1', 'Item 2', 'Item 3']}
-        choiceValues={['1', '2', '3']}
-        value={[]}
-        spacing="EVEN_MORE"
-      />
-    </div>
-  ),
 }
 
 export const ChoicePositionEnd: Story = {

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -9,6 +9,10 @@ const meta = {
   component: DialogField,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    width: { control: 'select', options: ['NARROW', 'MEDIUM', 'MEDIUM_PLUS', 'WIDE', 'FIT'] },
+    height: { control: 'select', options: ['AUTO', 'FIT', 'SHORT', 'MEDIUM', 'TALL'] },
+  },
 } satisfies Meta<typeof DialogField>
 
 export default meta

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -8,6 +8,10 @@ const meta = {
   component: DropdownField,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+    searchDisplay: { control: 'select', options: ['AUTO', 'ON', 'OFF'] },
+  },
 } satisfies Meta<typeof DropdownField>
 
 export default meta
@@ -102,20 +106,23 @@ export const AdjacentLabel: Story = {
 
 export const MultipleDefault: Story = {
   args: {
+    label: 'Language',
+    instructions: 'Which language(s) are you proficient in?',
     choiceLabels: ['English', 'Spanish', 'French', 'German'],
     choiceValues: ['en_US', 'es_ES', 'fr_FR', 'de_DE'],
+    searchDisplay: 'AUTO',
   },
-  render: () => {
+  render: (args) => {
     const [value, setValue] = useState<string[]>(['en_US', 'fr_FR'])
     return (
       <MultipleDropdownField
-        label="Language"
-        instructions="Which language(s) are you proficient in?"
-        choiceLabels={['English', 'Spanish', 'French', 'German']}
-        choiceValues={['en_US', 'es_ES', 'fr_FR', 'de_DE']}
+        label={args.label}
+        instructions={args.instructions}
+        choiceLabels={args.choiceLabels ?? []}
+        choiceValues={args.choiceValues ?? []}
         value={value}
         saveInto={(v) => setValue(v || [])}
-        searchDisplay="AUTO"
+        searchDisplay={args.searchDisplay}
       />
     )
   },
@@ -123,20 +130,23 @@ export const MultipleDefault: Story = {
 
 export const MultipleNoDefault: Story = {
   args: {
+    label: 'Skills',
+    instructions: 'Select all applicable skills',
     choiceLabels: ['JavaScript', 'TypeScript', 'React', 'Node.js', 'Python', 'Java'],
     choiceValues: ['js', 'ts', 'react', 'node', 'python', 'java'],
+    placeholder: 'Select skills',
   },
-  render: () => {
+  render: (args) => {
     const [value, setValue] = useState<string[]>([])
     return (
       <MultipleDropdownField
-        label="Skills"
-        instructions="Select all applicable skills"
-        choiceLabels={['JavaScript', 'TypeScript', 'React', 'Node.js', 'Python', 'Java']}
-        choiceValues={['js', 'ts', 'react', 'node', 'python', 'java']}
+        label={args.label}
+        instructions={args.instructions}
+        choiceLabels={args.choiceLabels ?? []}
+        choiceValues={args.choiceValues ?? []}
         value={value}
         saveInto={(v) => setValue(v || [])}
-        placeholder="Select skills"
+        placeholder={args.placeholder}
       />
     )
   },
@@ -144,6 +154,8 @@ export const MultipleNoDefault: Story = {
 
 export const MultipleWithSearch: Story = {
   args: {
+    label: 'Language',
+    instructions: 'Select all languages you speak',
     choiceLabels: [
       'English', 'Arabic', 'Chinese (Simplified)', 'Chinese (Traditional)',
       'Spanish', 'French', 'German', 'Japanese', 'Korean', 'Polish', 'Portuguese', 'Russian',
@@ -151,23 +163,19 @@ export const MultipleWithSearch: Story = {
     choiceValues: [
       'en_US', 'ar', 'zh_CN', 'zh_HK', 'es_ES', 'fr_FR', 'de_DE', 'ja', 'ko', 'pl', 'pt', 'ru',
     ],
+    searchDisplay: 'AUTO',
   },
-  render: () => {
+  render: (args) => {
     const [value, setValue] = useState<string[]>([])
     return (
       <MultipleDropdownField
-        label="Language"
-        instructions="Select all languages you speak"
-        choiceLabels={[
-          'English', 'Arabic', 'Chinese (Simplified)', 'Chinese (Traditional)',
-          'Spanish', 'French', 'German', 'Japanese', 'Korean', 'Polish', 'Portuguese', 'Russian',
-        ]}
-        choiceValues={[
-          'en_US', 'ar', 'zh_CN', 'zh_HK', 'es_ES', 'fr_FR', 'de_DE', 'ja', 'ko', 'pl', 'pt', 'ru',
-        ]}
+        label={args.label}
+        instructions={args.instructions}
+        choiceLabels={args.choiceLabels ?? []}
+        choiceValues={args.choiceValues ?? []}
         value={value}
         saveInto={(v) => setValue(v || [])}
-        searchDisplay="AUTO"
+        searchDisplay={args.searchDisplay}
       />
     )
   },
@@ -175,33 +183,37 @@ export const MultipleWithSearch: Story = {
 
 export const MultipleDisabled: Story = {
   args: {
+    label: 'Assigned Teams',
     choiceLabels: ['Engineering', 'Design', 'Marketing', 'Sales'],
     choiceValues: ['eng', 'design', 'marketing', 'sales'],
+    disabled: true,
   },
-  render: () => (
+  render: (args) => (
     <MultipleDropdownField
-      label="Assigned Teams"
-      choiceLabels={['Engineering', 'Design', 'Marketing', 'Sales']}
-      choiceValues={['eng', 'design', 'marketing', 'sales']}
+      label={args.label}
+      choiceLabels={args.choiceLabels ?? []}
+      choiceValues={args.choiceValues ?? []}
       value={['eng', 'design']}
-      disabled
+      disabled={args.disabled}
     />
   ),
 }
 
 export const MultipleAdjacentLabel: Story = {
   args: {
+    label: 'Categories',
+    labelPosition: 'ADJACENT',
     choiceLabels: ['Technology', 'Business', 'Science', 'Arts'],
     choiceValues: ['tech', 'biz', 'sci', 'arts'],
   },
-  render: () => {
+  render: (args) => {
     const [value, setValue] = useState<string[]>(['tech'])
     return (
       <MultipleDropdownField
-        label="Categories"
-        labelPosition="ADJACENT"
-        choiceLabels={['Technology', 'Business', 'Science', 'Arts']}
-        choiceValues={['tech', 'biz', 'sci', 'arts']}
+        label={args.label}
+        labelPosition={args.labelPosition}
+        choiceLabels={args.choiceLabels ?? []}
+        choiceValues={args.choiceValues ?? []}
         value={value}
         saveInto={(v) => setValue(v || [])}
       />

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -9,6 +9,15 @@ const meta = {
   args: {
     text: 'Heading Text',
   },
+  argTypes: {
+    size: { control: 'select', options: ['EXTRA_SMALL', 'SMALL', 'MEDIUM', 'MEDIUM_PLUS', 'LARGE', 'LARGE_PLUS'] },
+    headingTag: { control: 'select', options: ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'] },
+    fontWeight: { control: 'select', options: ['LIGHT', 'REGULAR', 'SEMI_BOLD', 'BOLD'] },
+    align: { control: 'select', options: ['START', 'CENTER', 'END'] },
+    marginAbove: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+    marginBelow: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+    color: { control: 'text' },
+  },
 } satisfies Meta<typeof HeadingField>
 
 export default meta

--- a/src/components/MessageBanner/MessageBanner.stories.tsx
+++ b/src/components/MessageBanner/MessageBanner.stories.tsx
@@ -13,6 +13,13 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    backgroundColor: { control: 'text' },
+    highlightColor: { control: 'text' },
+    icon: { control: 'select', options: ['info', 'success', 'warning', 'error'] },
+    shape: { control: 'select', options: ['SQUARED', 'SEMI_ROUNDED', 'ROUNDED'] },
+    marginBelow: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+  },
 } satisfies Meta<typeof MessageBanner>
 
 export default meta

--- a/src/components/Milestone/Milestone.stories.tsx
+++ b/src/components/Milestone/Milestone.stories.tsx
@@ -6,6 +6,12 @@ const meta = {
   component: MilestoneField,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    stepStyle: { control: 'select', options: ['DOT', 'BAR', 'CHEVRON'] },
+    orientation: { control: 'select', options: ['HORIZONTAL', 'VERTICAL'] },
+    color: { control: 'text' },
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+  },
 } satisfies Meta<typeof MilestoneField>
 
 export default meta

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -13,6 +13,11 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    style: { control: 'select', options: ['THIN', 'THICK'] },
+    color: { control: 'text' },
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+  },
 } satisfies Meta<typeof ProgressBar>
 
 export default meta

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -7,6 +7,13 @@ const meta = {
   component: RadioButtonField,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+    choiceLayout: { control: 'select', options: ['STACKED', 'COMPACT'] },
+    choiceStyle: { control: 'select', options: ['STANDARD', 'CARDS'] },
+    choicePosition: { control: 'select', options: ['START', 'END'] },
+    spacing: { control: 'select', options: ['STANDARD', 'MORE', 'EVEN_MORE'] },
+  },
 } satisfies Meta<typeof RadioButtonField>
 
 export default meta
@@ -104,40 +111,20 @@ export const Disabled: Story = {
 
 export const SpacingVariations: Story = {
   args: {
+    label: 'Standard Spacing',
     choiceLabels: ['Small', 'Medium', 'Large'],
     choiceValues: ['S', 'M', 'L'],
+    value: 'M',
+    spacing: 'STANDARD',
   },
-  render: () => {
-    const [standard, setStandard] = useState('M')
-    const [more, setMore] = useState('M')
-    const [evenMore, setEvenMore] = useState('M')
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
     return (
-      <div className="space-y-6">
-        <RadioButtonField
-          label="Standard Spacing"
-          choiceLabels={['Small', 'Medium', 'Large']}
-          choiceValues={['S', 'M', 'L']}
-          value={standard}
-          saveInto={setStandard}
-          spacing="STANDARD"
-        />
-        <RadioButtonField
-          label="More Spacing"
-          choiceLabels={['Small', 'Medium', 'Large']}
-          choiceValues={['S', 'M', 'L']}
-          value={more}
-          saveInto={setMore}
-          spacing="MORE"
-        />
-        <RadioButtonField
-          label="Even More Spacing"
-          choiceLabels={['Small', 'Medium', 'Large']}
-          choiceValues={['S', 'M', 'L']}
-          value={evenMore}
-          saveInto={setEvenMore}
-          spacing="EVEN_MORE"
-        />
-      </div>
+      <RadioButtonField
+        {...args}
+        value={value}
+        saveInto={setValue}
+      />
     )
   },
 }

--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.stories.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from 'storybook/test'
 import { ReadOnlyGrid } from './ReadOnlyGrid'
 import { GridColumn } from './GridColumn'
 
@@ -23,6 +24,15 @@ const meta = {
   component: ReadOnlyGrid,
   tags: ['autodocs'],
   parameters: { layout: 'padded' },
+  argTypes: {
+    borderStyle: { control: 'select', options: ['STANDARD', 'LIGHT'] },
+    spacing: { control: 'select', options: ['STANDARD', 'DENSE'] },
+    height: { control: 'select', options: ['SHORT', 'SHORT_PLUS', 'MEDIUM', 'MEDIUM_PLUS', 'TALL', 'TALL_PLUS', 'EXTRA_TALL', 'AUTO'] },
+    selectionStyle: { control: 'select', options: ['CHECKBOX', 'ROW_HIGHLIGHT'] },
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+    marginAbove: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+    marginBelow: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+  },
 } satisfies Meta<typeof ReadOnlyGrid>
 
 export default meta
@@ -30,8 +40,12 @@ type Story = StoryObj<typeof meta>
 
 /** 1. Default — Basic grid with employee data */
 export const Default: Story = {
-  render: () => (
-    <ReadOnlyGrid data={employees.slice(0, 5)} borderStyle='LIGHT'>
+  args: {
+    data: employees.slice(0, 5),
+    borderStyle: 'LIGHT',
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" sortField="name" />
       <GridColumn label="Department" value="department" />
       <GridColumn label="Salary" value="salary" sortField="salary" />
@@ -42,8 +56,12 @@ export const Default: Story = {
 
 /** 2. EmptyState — Empty data with custom message */
 export const EmptyState: Story = {
-  render: () => (
-    <ReadOnlyGrid data={[]} emptyGridMessage="No employees found matching your criteria.">
+  args: {
+    data: [],
+    emptyGridMessage: 'No employees found matching your criteria.',
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" />
       <GridColumn label="Department" value="department" />
       <GridColumn label="Salary" value="salary" />
@@ -53,24 +71,39 @@ export const EmptyState: Story = {
 
 /** 3. WithPaging — Full dataset with pageSize=5 showing paging controls */
 export const WithPaging: Story = {
-  render: () => (
-    <ReadOnlyGrid data={employees} pageSize={5}>
+  args: {
+    data: employees,
+    pageSize: 5,
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" sortField="name" />
       <GridColumn label="Department" value="department" sortField="department" />
       <GridColumn label="Salary" value="salary" sortField="salary" />
       <GridColumn label="Start Date" value="startDate" />
     </ReadOnlyGrid>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // Verify grid renders with data
+    await expect(canvas.getByText('Alice Johnson')).toBeVisible()
+    // Navigate to next page
+    const nextButton = canvas.getByRole('button', { name: /next page/i })
+    await userEvent.click(nextButton)
+    // First page data should no longer be visible, second page data should appear
+    await expect(canvas.getByText('Frank Miller')).toBeVisible()
+  },
 }
 
 /** 4. WithSorting — Sortable columns with initial sort on salary descending */
 export const WithSorting: Story = {
-  render: () => (
-    <ReadOnlyGrid
-      data={employees}
-      pageSize={6}
-      initialSorts={[{ field: "salary", ascending: false }]}
-    >
+  args: {
+    data: employees,
+    pageSize: 6,
+    initialSorts: [{ field: "salary", ascending: false }],
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" sortField="name" />
       <GridColumn label="Department" value="department" sortField="department" />
       <GridColumn label="Salary" value="salary" sortField="salary" />
@@ -81,15 +114,15 @@ export const WithSorting: Story = {
 
 /** 5. WithCheckboxSelection — Selectable grid with checkbox style */
 export const WithCheckboxSelection: Story = {
-  render: () => {
+  args: {
+    data: employees.slice(0, 6),
+    selectable: true,
+    selectionStyle: 'CHECKBOX',
+  },
+  render: (args) => {
     const [selected, setSelected] = React.useState<(string | number)[]>([])
     return (
-      <ReadOnlyGrid
-        data={employees.slice(0, 6)}
-        selectable
-        selectionValue={selected}
-        selectionSaveInto={setSelected}
-      >
+      <ReadOnlyGrid {...args} selectionValue={selected} selectionSaveInto={setSelected}>
         <GridColumn label="Name" value="name" />
         <GridColumn label="Department" value="department" />
         <GridColumn label="Salary" value="salary" />
@@ -100,16 +133,15 @@ export const WithCheckboxSelection: Story = {
 
 /** 6. WithRowHighlightSelection — ROW_HIGHLIGHT selection style */
 export const WithRowHighlightSelection: Story = {
-  render: () => {
+  args: {
+    data: employees.slice(0, 6),
+    selectable: true,
+    selectionStyle: 'ROW_HIGHLIGHT',
+  },
+  render: (args) => {
     const [selected, setSelected] = React.useState<(string | number)[]>([])
     return (
-      <ReadOnlyGrid
-        data={employees.slice(0, 6)}
-        selectable
-        selectionStyle="ROW_HIGHLIGHT"
-        selectionValue={selected}
-        selectionSaveInto={setSelected}
-      >
+      <ReadOnlyGrid {...args} selectionValue={selected} selectionSaveInto={setSelected}>
         <GridColumn label="Name" value="name" />
         <GridColumn label="Department" value="department" />
         <GridColumn label="Salary" value="salary" />
@@ -120,13 +152,14 @@ export const WithRowHighlightSelection: Story = {
 
 /** 7. StyledGrid — borderStyle, shadeAlternateRows, dense spacing */
 export const StyledGrid: Story = {
-  render: () => (
-    <ReadOnlyGrid
-      data={employees.slice(0, 8)}
-      borderStyle="STANDARD"
-      shadeAlternateRows
-      spacing="DENSE"
-    >
+  args: {
+    data: employees.slice(0, 8),
+    borderStyle: 'STANDARD',
+    shadeAlternateRows: true,
+    spacing: 'DENSE',
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" />
       <GridColumn label="Department" value="department" />
       <GridColumn label="Salary" value="salary" />
@@ -137,8 +170,12 @@ export const StyledGrid: Story = {
 
 /** 8. FixedHeight — MEDIUM height to show scrolling behavior */
 export const FixedHeight: Story = {
-  render: () => (
-    <ReadOnlyGrid data={employees} height="MEDIUM">
+  args: {
+    data: employees,
+    height: 'MEDIUM',
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" />
       <GridColumn label="Department" value="department" />
       <GridColumn label="Salary" value="salary" />
@@ -149,14 +186,15 @@ export const FixedHeight: Story = {
 
 /** 9. WithLabelAndValidations — label, instructions, validations, helpTooltip */
 export const WithLabelAndValidations: Story = {
-  render: () => (
-    <ReadOnlyGrid
-      label="Employee Directory"
-      instructions="Review the employee list below. Contact HR for updates."
-      helpTooltip="This grid shows all active employees."
-      validations={["Please select at least one employee.", "Salary data may be outdated."]}
-      data={employees.slice(0, 4)}
-    >
+  args: {
+    label: 'Employee Directory',
+    instructions: 'Review the employee list below. Contact HR for updates.',
+    helpTooltip: 'This grid shows all active employees.',
+    validations: ['Please select at least one employee.', 'Salary data may be outdated.'],
+    data: employees.slice(0, 4),
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" />
       <GridColumn label="Department" value="department" />
       <GridColumn label="Salary" value="salary" />
@@ -166,8 +204,11 @@ export const WithLabelAndValidations: Story = {
 
 /** 10. ColumnWidthsAndAlignment — Various column widths and alignments */
 export const ColumnWidthsAndAlignment: Story = {
-  render: () => (
-    <ReadOnlyGrid data={employees.slice(0, 5)}>
+  args: {
+    data: employees.slice(0, 5),
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="ID" value="id" width="ICON_PLUS" align="CENTER" />
       <GridColumn label="Name" value="name" width="WIDE" align="START" />
       <GridColumn label="Department" value="department" width="MEDIUM" align="CENTER" />
@@ -178,8 +219,11 @@ export const ColumnWidthsAndAlignment: Story = {
 
 /** 11. FunctionAccessor — Using function value accessors for computed columns */
 export const FunctionAccessor: Story = {
-  render: () => (
-    <ReadOnlyGrid data={employees.slice(0, 6)}>
+  args: {
+    data: employees.slice(0, 6),
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
       <GridColumn label="Name" value="name" />
       <GridColumn
         label="Formatted Salary"

--- a/src/components/RichText/RichText.stories.tsx
+++ b/src/components/RichText/RichText.stories.tsx
@@ -8,6 +8,12 @@ const meta = {
   component: RichTextDisplayField,
   tags: ['autodocs'],
   parameters: { layout: 'padded' },
+  argTypes: {
+    align: { control: 'select', options: ['LEFT', 'CENTER', 'RIGHT'] },
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+    marginAbove: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+    marginBelow: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+  },
 } satisfies Meta<typeof RichTextDisplayField>
 
 export default meta
@@ -24,115 +30,104 @@ export const Default: Story = {
 }
 
 export const UserProfileWithIcons: Story = {
-  render: () => (
-    <RichTextDisplayField
-      labelPosition="COLLAPSED"
-      value={[
-        <TextItem
-          text={[<Icon icon="user" caption="Name" />, ' Xavier Jones']}
-          size="MEDIUM"
-          style="STRONG"
-        />,
-        '\n',
-        <TextItem
-          text={[<Icon icon="phone" caption="Phone" />, ' (555) 123-4567']}
-          color="SECONDARY"
-        />,
-        '\n',
-        <TextItem
-          text={[<Icon icon="building" caption="Location" />, ' Reston, VA']}
-          color="SECONDARY"
-        />,
-      ]}
-    />
-  ),
+  args: {
+    labelPosition: 'COLLAPSED',
+    value: [
+      <TextItem
+        text={[<Icon icon="user" caption="Name" />, ' Xavier Jones']}
+        size="MEDIUM"
+        style="STRONG"
+      />,
+      '\n',
+      <TextItem
+        text={[<Icon icon="phone" caption="Phone" />, ' (555) 123-4567']}
+        color="SECONDARY"
+      />,
+      '\n',
+      <TextItem
+        text={[<Icon icon="building" caption="Location" />, ' Reston, VA']}
+        color="SECONDARY"
+      />,
+    ],
+  },
 }
 
-
 export const TextStyles: Story = {
-  render: () => (
-    <RichTextDisplayField
-      labelPosition="COLLAPSED"
-      value={[
-        <TextItem text="Plain, " style="PLAIN" />,
-        <TextItem text="Emphasis Small, " style="EMPHASIS" size="SMALL" />,
-        <TextItem text="Underline Medium, " style="UNDERLINE" size="MEDIUM" />,
-        <TextItem text="Strikethrough Medium_Plus, " style="STRIKETHROUGH" size="MEDIUM_PLUS" />,
-        <TextItem text="Strong Large, " style="STRONG" size="LARGE" />,
-        <TextItem text="Emphasis Large_Plus " style="EMPHASIS" size="LARGE_PLUS" />,
-        <TextItem text="Strong Extra_Large" style="STRONG" size="EXTRA_LARGE" />,
-      ]}
-    />
-  ),
+  args: {
+    labelPosition: 'COLLAPSED',
+    value: [
+      <TextItem text="Plain, " style="PLAIN" />,
+      <TextItem text="Emphasis Small, " style="EMPHASIS" size="SMALL" />,
+      <TextItem text="Underline Medium, " style="UNDERLINE" size="MEDIUM" />,
+      <TextItem text="Strikethrough Medium_Plus, " style="STRIKETHROUGH" size="MEDIUM_PLUS" />,
+      <TextItem text="Strong Large, " style="STRONG" size="LARGE" />,
+      <TextItem text="Emphasis Large_Plus " style="EMPHASIS" size="LARGE_PLUS" />,
+      <TextItem text="Strong Extra_Large" style="STRONG" size="EXTRA_LARGE" />,
+    ],
+  },
 }
 
 export const InteractiveLinks: Story = {
-  render: () => (
-    <RichTextDisplayField
-      value={[
-        'In addition to a personal statement, candidates may submit up to three ',
-        <TextItem
-          text={[<Icon icon="image" />, ' Fine Art']}
-          link={() => alert('Fine Art clicked!')}
-        />,
-        ', ',
-        <TextItem
-          text={[<Icon icon="headphones" />, ' Audio']}
-          link={() => alert('Audio clicked!')}
-        />,
-        ', or ',
-        <TextItem
-          text={[<Icon icon="video" />, ' Video']}
-          link={() => alert('Video clicked!')}
-        />,
-        ' media samples.',
-      ]}
-    />
-  ),
+  args: {
+    value: [
+      'In addition to a personal statement, candidates may submit up to three ',
+      <TextItem
+        text={[<Icon icon="image" />, ' Fine Art']}
+        link={() => alert('Fine Art clicked!')}
+      />,
+      ', ',
+      <TextItem
+        text={[<Icon icon="headphones" />, ' Audio']}
+        link={() => alert('Audio clicked!')}
+      />,
+      ', or ',
+      <TextItem
+        text={[<Icon icon="video" />, ' Video']}
+        link={() => alert('Video clicked!')}
+      />,
+      ' media samples.',
+    ],
+  },
 }
 
 export const StandaloneNavigationLinks: Story = {
-  render: () => (
-    <RichTextDisplayField
-      value={[
-        <TextItem
-          text={[<Icon icon="home" />, ' Home']}
-          link={() => alert('Home clicked!')}
-          linkStyle="STANDALONE"
-        />,
-        '\n',
-        <TextItem
-          text={[<Icon icon="square-check" />, ' My Open Requests']}
-          link={() => alert('Requests clicked!')}
-          linkStyle="STANDALONE"
-        />,
-        '\n',
-        <TextItem
-          text={[<Icon icon="fileText" />, ' My Documents']}
-          link={() => alert('Documents clicked!')}
-          linkStyle="INLINE"
-        />,
-      ]}
-    />
-  ),
+  args: {
+    value: [
+      <TextItem
+        text={[<Icon icon="home" />, ' Home']}
+        link={() => alert('Home clicked!')}
+        linkStyle="STANDALONE"
+      />,
+      '\n',
+      <TextItem
+        text={[<Icon icon="square-check" />, ' My Open Requests']}
+        link={() => alert('Requests clicked!')}
+        linkStyle="STANDALONE"
+      />,
+      '\n',
+      <TextItem
+        text={[<Icon icon="fileText" />, ' My Documents']}
+        link={() => alert('Documents clicked!')}
+        linkStyle="INLINE"
+      />,
+    ],
+  },
 }
 
 export const ColorVariations: Story = {
-  render: () => (
-    <RichTextDisplayField
-      value={[
-        <TextItem text="Semantic Colors: " />,
-        <TextItem text="ACCENT " color="ACCENT" style="STRONG" />,
-        <TextItem text="POSITIVE " color="POSITIVE" style="STRONG" />,
-        <TextItem text="NEGATIVE " color="NEGATIVE" style="STRONG" />,
-        <TextItem text="SECONDARY " color="SECONDARY" style="STRONG" />,
-        '\n',
-        <TextItem text="Custom Colors: " />,
-        <TextItem text="Custom Red " color="#FF0000" style="STRONG" />,
-        <TextItem text="Custom Blue " color="#0066CC" style="STRONG" />,
-      ]}
-    />
-  ),
+  args: {
+    value: [
+      <TextItem text="Semantic Colors: " />,
+      <TextItem text="ACCENT " color="ACCENT" style="STRONG" />,
+      <TextItem text="POSITIVE " color="POSITIVE" style="STRONG" />,
+      <TextItem text="NEGATIVE " color="NEGATIVE" style="STRONG" />,
+      <TextItem text="SECONDARY " color="SECONDARY" style="STRONG" />,
+      '\n',
+      <TextItem text="Custom Colors: " />,
+      <TextItem text="Custom Red " color="#FF0000" style="STRONG" />,
+      <TextItem text="Custom Blue " color="#0066CC" style="STRONG" />,
+    ],
+  },
 }
 
 export const TextAlignment: Story = {

--- a/src/components/Stamp/Stamp.stories.tsx
+++ b/src/components/Stamp/Stamp.stories.tsx
@@ -6,6 +6,14 @@ const meta = {
   component: StampField,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['TINY', 'SMALL', 'MEDIUM', 'LARGE'] },
+    shape: { control: 'select', options: ['SQUARED', 'SEMI_ROUNDED', 'ROUNDED'] },
+    align: { control: 'select', options: ['START', 'CENTER', 'END'] },
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+    backgroundColor: { control: 'text' },
+    contentColor: { control: 'text' },
+  },
 } satisfies Meta<typeof StampField>
 
 export default meta
@@ -40,13 +48,11 @@ export const TransparentBackground: Story = {
 }
 
 export const TextStamps: Story = {
-  render: () => (
-    <div className="flex gap-4 items-center">
-      <StampField backgroundColor="#cc0000" text="1" align="CENTER" />
-      <StampField backgroundColor="#cc0000" text="2" align="CENTER" />
-      <StampField backgroundColor="#cc0000" text="3" align="CENTER" />
-    </div>
-  ),
+  args: {
+    backgroundColor: '#cc0000',
+    text: '1',
+    align: 'CENTER',
+  },
 }
 
 export const Sizes: Story = {

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from 'storybook/test'
 import { useState } from 'react'
 import { SwitchField } from './SwitchField'
 
@@ -21,6 +22,14 @@ export const Default: Story = {
   render: (args) => {
     const [value, setValue] = useState(args.value)
     return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const switchEl = canvas.getByRole('switch')
+    await expect(switchEl).toBeVisible()
+    await expect(switchEl).toBeChecked()
+    await userEvent.click(switchEl)
+    await expect(switchEl).not.toBeChecked()
   },
 }
 

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -11,6 +11,12 @@ const meta = {
   component: TabsField,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['SMALL', 'STANDARD', 'LARGE'] },
+    color: { control: 'text' },
+    orientation: { control: 'select', options: ['HORIZONTAL', 'VERTICAL'] },
+    activationMode: { control: 'select', options: ['AUTOMATIC', 'MANUAL'] },
+  },
 } satisfies Meta<typeof TabsField>
 
 export default meta

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -12,6 +12,10 @@ const meta = {
       { text: 'ACTIVE', backgroundColor: 'POSITIVE' },
     ],
   },
+  argTypes: {
+    size: { control: 'select', options: ['SMALL', 'STANDARD'] },
+    marginBelow: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
+  },
 } satisfies Meta<typeof TagField>
 
 export default meta
@@ -20,29 +24,25 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {}
 
 export const SemanticColors: Story = {
-  render: () => (
-    <TagField
-      size="STANDARD"
-      tags={[
-        { text: 'HIGH PRIORITY', backgroundColor: 'NEGATIVE' },
-        { text: 'REVIEWED', backgroundColor: 'POSITIVE' },
-        { text: 'NEW', backgroundColor: 'ACCENT' },
-      ]}
-    />
-  ),
+  args: {
+    size: 'STANDARD',
+    tags: [
+      { text: 'HIGH PRIORITY', backgroundColor: 'NEGATIVE' },
+      { text: 'REVIEWED', backgroundColor: 'POSITIVE' },
+      { text: 'NEW', backgroundColor: 'ACCENT' },
+    ],
+  },
 }
 
 export const CustomHexColors: Story = {
-  render: () => (
-    <TagField
-      size="STANDARD"
-      tags={[
-        { text: 'URGENT', backgroundColor: '#FED7DE', textColor: '#9F0019' },
-        { text: 'CUSTOMER FACING', backgroundColor: '#DBECFF', textColor: '#0C4283' },
-        { text: 'IN PROGRESS', backgroundColor: '#FFF6C9', textColor: '#856C00' },
-      ]}
-    />
-  ),
+  args: {
+    size: 'STANDARD',
+    tags: [
+      { text: 'URGENT', backgroundColor: '#FED7DE', textColor: '#9F0019' },
+      { text: 'CUSTOMER FACING', backgroundColor: '#DBECFF', textColor: '#0C4283' },
+      { text: 'IN PROGRESS', backgroundColor: '#FFF6C9', textColor: '#856C00' },
+    ],
+  },
 }
 
 export const SmallSize: Story = {

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from 'storybook/test'
 import { TextField } from './TextField'
 
 const meta = {
@@ -14,6 +15,10 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
+    align: { control: 'select', options: ['LEFT', 'CENTER', 'RIGHT'] },
+  },
 } satisfies Meta<typeof TextField>
 
 export default meta
@@ -24,6 +29,18 @@ export const Default: Story = {
     label: 'Email Address',
     placeholder: 'user@example.com',
     required: true,
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '')
+    return <TextField {...args} value={value} saveInto={setValue} />
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByLabelText(/email address/i)
+    await expect(input).toBeVisible()
+    await userEvent.click(input)
+    await userEvent.type(input, 'test@example.com')
+    await expect(input).toHaveValue('test@example.com')
   },
 }
 
@@ -82,19 +99,23 @@ export const WithHelpTooltip: Story = {
 }
 
 export const WithValidationError: Story = {
-  render: () => {
-    const [email, setEmail] = useState('invalid-email')
+  args: {
+    label: 'Email Address',
+    placeholder: 'user@example.com',
+    value: 'invalid-email',
+    required: true,
+  },
+  render: (args) => {
+    const [email, setEmail] = useState(args.value ?? '')
     const validations = email && !email.includes('@')
       ? ['Please enter a valid email address']
       : []
 
     return (
       <TextField
-        label="Email Address"
-        placeholder="user@example.com"
+        {...args}
         value={email}
         saveInto={setEmail}
-        required
         validations={validations}
       />
     )

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from 'storybook/test'
 import { useState } from 'react'
 import { ToggleField } from './ToggleField'
 
@@ -22,6 +23,16 @@ export const Default: Story = {
   render: (args) => {
     const [value, setValue] = useState(args.value)
     return <ToggleField {...args} value={value} saveInto={setValue} />
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const toggle = canvas.getByRole('button', { name: /bold/i })
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    await userEvent.click(toggle)
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    await userEvent.click(toggle)
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
   },
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,52 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'
+import { playwright } from '@vitest/browser-playwright'
+
+const dirname = typeof __dirname !== 'undefined'
+  ? __dirname
+  : path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/test/setup.ts'],
+    projects: [
+      // Unit tests (existing)
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          environment: 'jsdom',
+          globals: true,
+          setupFiles: ['./src/test/setup.ts'],
+          include: ['src/**/*.test.{ts,tsx}'],
+        },
+      },
+      // Storybook component + a11y tests
+      {
+        extends: true,
+        plugins: [
+          storybookTest({ configDir: path.join(dirname, '.storybook') }),
+        ],
+        optimizeDeps: {
+          include: [
+            '@storybook/react/entry-preview',
+            '@storybook/addon-a11y/preview',
+          ],
+        },
+        test: {
+          name: 'storybook',
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: 'chromium' }],
+          },
+          setupFiles: ['.storybook/vitest.setup.ts'],
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
## Summary

Addresses #47 (args for interactive controls) and #45 (testing infrastructure).

### Args & interactive controls (#47)
- Added `argTypes` with proper control types (select, text, boolean) to all component story metas
- Converted single-component stories to use `args` + `render: (args) =>` pattern for interactive Storybook controls
- Multi-variant showcase stories kept as bare `render: () =>` since they intentionally show multiple variants side-by-side

### Testing infrastructure (#45)
- Configured `@storybook/addon-vitest` with Playwright browser mode (Chromium, headless)
- Created `.storybook/vitest.setup.ts` with React renderer + a11y addon annotations
- Added interaction tests (`play` functions) for Button, Checkbox, TextField, and ReadOnlyGrid WithPaging
- Enabled a11y testing (`test: 'error'`) in preview config — all stories pass a11y checks
- Vitest config uses `test.projects` with separate `unit` (jsdom) and `storybook` (browser) projects
- Added `test-storybook` and `test:unit` npm scripts

### Test results
- 198 storybook tests pass (34 files)
- 65 unit tests pass (2 files)
- Storybook build passes
- Vite build passes

Closes #45, closes #47