### PR TITLE
fix: adjust button padding for icon-only state

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -133,13 +133,13 @@ export const LinkStyle: Story = {
 }
 
 export const MixedButtonTypes: Story = {
-  name: 'Mixed Icon-Label Combinations',
+  name: 'Icon Buttons',
   render: () => (
     <ButtonArrayLayout
       buttons={[
-        { label: '', icon: 'coffee', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
-        { label: 'Coffee', icon: 'coffee', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
-        { label: 'Coffee', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
+        { label: '', icon: 'send', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
+        { label: 'Send', icon: 'send', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
+        { label: 'Send', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
       ]}
     />
   ),

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -131,3 +131,16 @@ export const LinkStyle: Story = {
     color: 'ACCENT',
   },
 }
+
+export const MixedButtonTypes: Story = {
+  name: 'Mixed Icon-Label Combinations',
+  render: () => (
+    <ButtonArrayLayout
+      buttons={[
+        { label: '', icon: 'coffee', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
+        { label: 'Coffee', icon: 'coffee', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
+        { label: 'Coffee', style: 'SOLID', color: 'ACCENT', size: 'MEDIUM' },
+      ]}
+    />
+  ),
+}

--- a/src/components/Button/ButtonWidget.tsx
+++ b/src/components/Button/ButtonWidget.tsx
@@ -94,8 +94,8 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   const sizeMap: Record<SAILSize, string> = {
     SMALL: 'px-3 py-2 text-sm leading-none',
     STANDARD: 'px-4 py-3 text-base leading-none',
-    MEDIUM: 'px-6 py-4 text-lg leading-none',
-    LARGE: 'px-10 py-5 text-xl leading-none'
+    MEDIUM: 'px-5 py-4 text-lg leading-none',
+    LARGE: 'px-6 py-5 text-xl leading-none'
   }
 
   // Icon-only size mappings — uniform padding for square aspect ratio

--- a/src/components/Button/ButtonWidget.tsx
+++ b/src/components/Button/ButtonWidget.tsx
@@ -98,6 +98,17 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
     LARGE: 'px-10 py-4 text-xl'      // 40px horizontal, 16px vertical
   }
 
+  // Icon-only size mappings — adjusted vertical padding for buttons with icon but no label
+  const iconOnlySizeMap: Record<SAILSize, string> = {
+    SMALL: 'px-3 py-2.75 text-sm',
+    STANDARD: 'px-4 py-3 text-base',
+    MEDIUM: 'px-6 py-4.25 text-lg',
+    LARGE: 'px-10 py-5 text-xl'
+  }
+
+  const isIconOnly = !!icon && !label
+  const effectiveSizeClasses = isIconOnly ? iconOnlySizeMap[size] : sizeMap[size]
+
   // Width mappings
   const widthClass = width === "FILL" ? 'w-full' : 'w-auto'
 
@@ -210,7 +221,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
     inline-flex items-center justify-center gap-1
     font-medium transition-colors h-auto rounded-sm
     focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2
-    ${sizeMap[size]}
+    ${effectiveSizeClasses}
     ${widthClass}
     ${getBorderClasses()}
     ${getColorClasses()}

--- a/src/components/Button/ButtonWidget.tsx
+++ b/src/components/Button/ButtonWidget.tsx
@@ -90,20 +90,20 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   // Visibility control
   if (!showWhen) return null
 
-  // Size mappings - using standard Tailwind spacing classes
+  // Size mappings - leading-none removes line-height so button height is purely padding-driven
   const sizeMap: Record<SAILSize, string> = {
-    SMALL: 'px-3 py-2 text-sm',      // 12px horizontal, 8px vertical
-    STANDARD: 'px-4 py-2 text-base', // 16px horizontal, 8px vertical (matches input height)
-    MEDIUM: 'px-6 py-3 text-lg',     // 24px horizontal, 12px vertical
-    LARGE: 'px-10 py-4 text-xl'      // 40px horizontal, 16px vertical
+    SMALL: 'px-3 py-2 text-sm leading-none',
+    STANDARD: 'px-4 py-3 text-base leading-none',
+    MEDIUM: 'px-6 py-4 text-lg leading-none',
+    LARGE: 'px-10 py-5 text-xl leading-none'
   }
 
-  // Icon-only size mappings — adjusted vertical padding for buttons with icon but no label
+  // Icon-only size mappings — uniform padding for square aspect ratio
   const iconOnlySizeMap: Record<SAILSize, string> = {
-    SMALL: 'px-3 py-2.75 text-sm',
-    STANDARD: 'px-4 py-3 text-base',
-    MEDIUM: 'px-6 py-4.25 text-lg',
-    LARGE: 'px-10 py-5 text-xl'
+    SMALL: 'p-2 text-sm',
+    STANDARD: 'p-3 text-base',
+    MEDIUM: 'p-4 text-lg',
+    LARGE: 'p-5 text-xl'
   }
 
   const isIconOnly = !!icon && !label


### PR DESCRIPTION
Adds proper padding handling for icon-only buttons in ButtonWidget so they render as square buttons instead of using the same horizontal padding as labeled buttons.