### PR TITLE
feat: add RecordView template with SiteNav and pill tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-switch": "^1.2.6",
@@ -174,6 +175,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -546,6 +548,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -586,6 +589,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1204,6 +1208,44 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1595,6 +1637,29 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
@@ -1756,6 +1821,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1810,6 +1904,78 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2193,6 +2359,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
@@ -2210,6 +2394,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://artifacts.eng.appianci.net:443/artifactory/api/npm/npmjs/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.38",
@@ -2635,6 +2825,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3411,8 +3602,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3511,6 +3701,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3521,6 +3712,7 @@
       "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3531,6 +3723,7 @@
       "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3588,6 +3781,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -3840,6 +4034,7 @@
       "integrity": "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.18",
         "@vitest/utils": "4.0.18",
@@ -3863,6 +4058,7 @@
       "integrity": "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -4079,6 +4275,7 @@
       "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "pathe": "^2.0.3"
@@ -4319,6 +4516,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4418,7 +4616,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4642,6 +4839,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -5034,8 +5232,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.228",
@@ -5095,6 +5292,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5159,6 +5357,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6277,6 +6476,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -6722,7 +6922,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7283,6 +7482,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7315,7 +7515,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7331,7 +7530,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7409,6 +7607,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7450,6 +7649,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7462,8 +7662,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -7646,6 +7845,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7843,6 +8043,7 @@
       "integrity": "sha512-UUm5eGSm6BLhkcFP0WbxkmAHJZfVN2ViLpIZOqiIPS++q32VYn+CLFC0lrTYTDqYvaG7i4BK4uowXYujzE4NdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -8078,6 +8279,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8237,6 +8439,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8431,6 +8634,7 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -8551,6 +8755,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8564,6 +8769,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-switch": "^1.2.6",

--- a/src/components/RecordView/RecordView.stories.tsx
+++ b/src/components/RecordView/RecordView.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { RecordView } from './RecordView'
+import type { RecordAction, RecordViewProps } from './RecordView'
+import type { SiteNavPage } from '../SiteNav'
+import {
+  Home,
+  List,
+  Inbox,
+  FolderOpen,
+  BarChart3,
+  Search,
+  MessagesSquare,
+} from 'lucide-react'
+import { useState, useEffect } from 'react'
+
+/** Shared render function that wires up stateful view switching */
+const InteractiveRender = (args: RecordViewProps) => {
+  const [viewIndex, setViewIndex] = useState(args.selectedViewIndex ?? 0)
+
+  useEffect(() => {
+    setViewIndex(args.selectedViewIndex ?? 0)
+  }, [args.selectedViewIndex])
+
+  return (
+    <RecordView {...args} selectedViewIndex={viewIndex} onViewChange={setViewIndex} />
+  )
+}
+
+const meta = {
+  title: 'Templates/RecordView',
+  component: RecordView,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  render: InteractiveRender,
+} satisfies Meta<typeof RecordView>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const sitePages: SiteNavPage[] = [
+  { label: 'Home', icon: Home },
+  { label: 'Records', icon: List, isSelected: true },
+  { label: 'Inbox', icon: Inbox, badge: '(3)' },
+  {
+    label: 'Directory',
+    icon: FolderOpen,
+    isGroup: true,
+    children: [
+      { label: 'People' },
+      { label: 'Teams' },
+    ],
+  },
+  { label: 'Reports', icon: BarChart3 },
+  { label: 'Search', icon: Search },
+  { label: 'Chat', icon: MessagesSquare },
+]
+
+const recordActions: RecordAction[] = [
+  { label: 'EDIT' },
+  { label: 'APPROVE' },
+  { label: 'EXPORT' },
+  { label: 'Archive' },
+  { label: 'Delete' },
+]
+
+const recordViews = [
+  { label: 'Summary', content: (
+    <div className="p-6">
+      <div className="bg-white border border-gray-200 rounded-sm p-4 mb-4">
+        <h2 className="text-base font-semibold text-gray-900 mb-2">Overview</h2>
+        <p className="text-sm text-gray-600">This is the summary view content.</p>
+      </div>
+    </div>
+  )},
+  { label: 'Details', content: (
+    <div className="p-6">
+      <div className="bg-white border border-gray-200 rounded-sm p-4">
+        <h2 className="text-base font-semibold text-gray-900 mb-2">Record Details</h2>
+        <p className="text-sm text-gray-600">This is the details view content.</p>
+      </div>
+    </div>
+  )},
+  { label: 'Activity', content: (
+    <div className="p-6">
+      <p className="text-sm text-gray-400">No recent activity.</p>
+    </div>
+  )},
+  { label: 'Documents' },
+  { label: 'History' },
+]
+
+export const Default: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    recordTitle: 'REC-001 | Sample Record',
+    recordActions,
+    views: recordViews,
+    userName: 'Jane Doe',
+    selectedViewIndex: 0,
+  },
+}
+
+export const CollapsedNav: Story = {
+  args: {
+    ...Default.args,
+    collapsed: true,
+  },
+}
+
+export const MinimalRecord: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: [{ label: 'Home', icon: Home, isSelected: true }],
+    recordTitle: 'Case #12345',
+    recordActions: [{ label: 'EDIT' }],
+    views: [{ label: 'Summary' }, { label: 'History' }],
+    userName: 'Alex Brown',
+    selectedViewIndex: 0,
+  },
+}
+
+export const NoActions: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    recordTitle: 'Read-Only Record',
+    recordActions: [],
+    views: [{ label: 'Summary' }, { label: 'Details' }],
+    userName: 'Jane Doe',
+    selectedViewIndex: 0,
+  },
+}
+
+export const ManyActions: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    recordTitle: 'REC-002 | Record With Many Actions',
+    recordActions: [
+      { label: 'UPDATE' },
+      { label: 'CREATE DOCUMENT' },
+      { label: 'UPLOAD DOCUMENTS' },
+      { label: 'Submit for Review' },
+      { label: 'Submit to Contracting' },
+      { label: 'Mark Inactive' },
+      { label: 'Copy Record' },
+    ],
+    views: recordViews,
+    userName: 'Jane Doe',
+    selectedViewIndex: 0,
+  },
+}

--- a/src/components/RecordView/RecordView.stories.tsx
+++ b/src/components/RecordView/RecordView.stories.tsx
@@ -12,6 +12,10 @@ import {
   MessagesSquare,
 } from 'lucide-react'
 import { useState, useEffect } from 'react'
+import { CardLayout } from '../Card/CardLayout'
+import { HeadingField } from '../Heading/HeadingField'
+import { RichTextDisplayField } from '../RichText/RichTextDisplayField'
+import { TextItem } from '../RichText/TextItem'
 
 /** Shared render function that wires up stateful view switching */
 const InteractiveRender = (args: RecordViewProps) => {
@@ -66,23 +70,23 @@ const recordActions: RecordAction[] = [
 const recordViews = [
   { label: 'Summary', content: (
     <div className="p-6">
-      <div className="bg-white border border-gray-200 rounded-sm p-4 mb-4">
-        <h2 className="text-base font-semibold text-gray-900 mb-2">Overview</h2>
-        <p className="text-sm text-gray-600">This is the summary view content.</p>
-      </div>
+      <CardLayout padding="STANDARD">
+        <HeadingField text="Overview" size="MEDIUM" marginBelow="LESS" fontWeight="SEMI_BOLD" />
+        <RichTextDisplayField value={["This is the summary view content."]} />
+      </CardLayout>
     </div>
   )},
   { label: 'Details', content: (
     <div className="p-6">
-      <div className="bg-white border border-gray-200 rounded-sm p-4">
-        <h2 className="text-base font-semibold text-gray-900 mb-2">Record Details</h2>
-        <p className="text-sm text-gray-600">This is the details view content.</p>
-      </div>
+      <CardLayout padding="STANDARD">
+        <HeadingField text="Record Details" size="MEDIUM" marginBelow="LESS" fontWeight="SEMI_BOLD" />
+        <RichTextDisplayField value={["This is the details view content."]} />
+      </CardLayout>
     </div>
   )},
   { label: 'Activity', content: (
     <div className="p-6">
-      <p className="text-sm text-gray-400">No recent activity.</p>
+      <RichTextDisplayField value={[<TextItem key="activity" text="No recent activity." color="SECONDARY" />]} />
     </div>
   )},
   { label: 'Documents' },

--- a/src/components/RecordView/RecordView.tsx
+++ b/src/components/RecordView/RecordView.tsx
@@ -1,0 +1,239 @@
+import * as React from 'react'
+import { SiteNav } from '../SiteNav'
+import type { SiteNavPage } from '../SiteNav'
+import { ButtonArrayLayout } from '../Button/ButtonArrayLayout'
+import { ButtonWidget } from '../Button/ButtonWidget'
+import { TabsField } from '../Tabs'
+
+/** Semantic color for active tab styling — maps to Appian's primary brand color */
+const ACTIVE_TAB_COLOR = 'ACCENT'
+
+/**
+ * Record action button configuration.
+ * Maps to SAIL's related action buttons shown in the record header.
+ */
+export interface RecordAction {
+  /** Button label */
+  label: string
+  /** Click handler */
+  onClick?: () => void
+}
+
+/**
+ * Record view tab configuration.
+ * Maps to SAIL's record view tabs (Summary, Addresses, etc.)
+ */
+export interface RecordViewTab {
+  /** Tab label */
+  label: string
+  /** Content to display when this view is active */
+  content?: React.ReactNode
+  /** Whether this tab is the active view. Ignored when selectedViewIndex is provided on RecordView. */
+  isSelected?: boolean
+  /** Click handler */
+  onClick?: () => void
+}
+
+/**
+ * Props for the RecordView template.
+ * Composes SiteNav + record header + view tabs + content slot.
+ */
+export interface RecordViewProps {
+  /* --- Site Nav props --- */
+  /** Site/solution display name */
+  displayName?: string
+  /** Site pages for the left nav */
+  pages: SiteNavPage[]
+  /** Controlled collapsed state */
+  collapsed?: boolean
+  /** Collapse toggle callback */
+  onCollapseToggle?: (collapsed: boolean) => void
+  /** User full name */
+  userName?: string
+  /** Appian logo path */
+  appianLogoSrc?: string
+  /** Highlight color for selected nav item (passed to SiteNav) */
+  highlightColor?: string
+
+  /* --- Record header props --- */
+  /** Record title (e.g. "REC-001 | Sample Record") */
+  recordTitle: string
+  /** Record action buttons shown in the record header. First 3 are shown as buttons; extras appear in an overflow dropdown. */
+  recordActions?: RecordAction[]
+  /** Record view tabs */
+  views?: RecordViewTab[]
+  /** Index of the currently selected view (controlled). When provided, overrides isSelected on individual tabs. */
+  selectedViewIndex?: number
+  /** Callback when a view tab is clicked. Receives the index of the clicked tab. */
+  onViewChange?: (index: number) => void
+
+  /* --- Content slot --- */
+  /** Content to render inside the active view area. This is the slot UXDs fill in. */
+  children?: React.ReactNode
+}
+
+/** Maximum number of action buttons shown before overflow */
+const MAX_VISIBLE_ACTIONS = 3
+
+/**
+ * RecordActions — renders visible action buttons with an overflow dropdown
+ * when there are more than MAX_VISIBLE_ACTIONS.
+ */
+const RecordActions: React.FC<{ actions: RecordAction[] }> = ({ actions }) => {
+  const [overflowOpen, setOverflowOpen] = React.useState(false)
+  const overflowRef = React.useRef<HTMLDivElement>(null)
+
+  const visibleActions = actions.slice(0, MAX_VISIBLE_ACTIONS)
+  const overflowActions = actions.slice(MAX_VISIBLE_ACTIONS)
+
+  // Close dropdown when clicking outside
+  React.useEffect(() => {
+    if (!overflowOpen) return
+    const handleClickOutside = (e: MouseEvent) => {
+      if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) {
+        setOverflowOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [overflowOpen])
+
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <ButtonArrayLayout
+        buttons={visibleActions.map((action) => ({
+          label: action.label,
+          style: 'OUTLINE' as const,
+          color: 'ACCENT',
+          size: 'SMALL' as const,
+          onClick: action.onClick,
+        }))}
+        marginBelow="NONE"
+      />
+      {overflowActions.length > 0 && (
+        <div className="relative" ref={overflowRef}>
+          <ButtonWidget
+            icon="ellipsis"
+            style="OUTLINE"
+            color="ACCENT"
+            size="SMALL"
+            accessibilityText="More actions"
+            tooltip="More actions"
+            onClick={() => setOverflowOpen((prev) => !prev)}
+          />
+          {overflowOpen && (
+            <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-sm shadow-lg z-10 min-w-48">
+              {overflowActions.map((action) => (
+                <button
+                  key={action.label}
+                  onClick={() => {
+                    action.onClick?.()
+                    setOverflowOpen(false)
+                  }}
+                  className="block w-full text-left px-4 py-2.5 text-sm text-gray-800 hover:bg-gray-100 transition-colors cursor-pointer"
+                >
+                  {action.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * RecordView Template
+ *
+ * A page-level template for prototyping Appian record views.
+ * Provides the full page shell: site sidebar nav on the left,
+ * record header (title + actions + view tabs) on the right,
+ * and a content slot for UXDs to fill in with their specific view content.
+ *
+ * Maps to SAIL's a!navigationLayout (SIDEBAR) wrapping a!headerContentLayout
+ * with record views and related actions.
+ */
+export const RecordView: React.FC<RecordViewProps> = ({
+  // Site nav
+  displayName,
+  pages,
+  collapsed,
+  onCollapseToggle,
+  userName,
+  appianLogoSrc,
+  highlightColor,
+
+  // Record header
+  recordTitle,
+  recordActions = [],
+  views = [],
+  selectedViewIndex,
+  onViewChange,
+
+  // Content
+  children,
+}) => {
+  return (
+    <div className="flex h-screen w-full overflow-hidden bg-gray-50">
+      {/* Left: Site Navigation */}
+      <SiteNav
+        displayName={displayName}
+        pages={pages}
+        collapsed={collapsed}
+        onCollapseToggle={onCollapseToggle}
+        userName={userName}
+        appianLogoSrc={appianLogoSrc}
+        highlightColor={highlightColor}
+      />
+
+      {/* Right: Record content area */}
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        {/* Record header: title + actions */}
+        <div className="flex items-center justify-between px-6 pt-3 pb-2 bg-gray-50 shrink-0">
+          <h1 className="text-3xl font-semibold text-gray-900 truncate mr-4">
+            {recordTitle}
+          </h1>
+
+          {recordActions.length > 0 && (
+            <RecordActions actions={recordActions} />
+          )}
+        </div>
+
+        {/* Record view tabs + content */}
+        {views.length > 0 && (
+          <div className="px-6 pt-1.5 pb-3 bg-gray-50 shrink-0">
+            <TabsField
+              tabs={views.map((view, index) => ({
+                value: String(index),
+                label: view.label,
+                content: view.content ?? null,
+              }))}
+              value={selectedViewIndex !== undefined ? String(selectedViewIndex) : undefined}
+              defaultValue="0"
+              onValueChange={(val) => {
+                const idx = Number(val)
+                onViewChange?.(idx)
+                views[idx]?.onClick?.()
+              }}
+              variant="PILL"
+              size="SMALL"
+              color={ACTIVE_TAB_COLOR}
+              marginAbove="NONE"
+              marginBelow="NONE"
+            />
+          </div>
+        )}
+
+        {/* Content slot — used when views don't provide their own content */}
+        <div className="flex-1 overflow-y-auto bg-gray-50">
+          {children || (
+            <div className="p-6 text-gray-400 text-sm">
+              Record view content goes here. Replace this with your view components.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/RecordView/RecordView.tsx
+++ b/src/components/RecordView/RecordView.tsx
@@ -8,12 +8,11 @@ import { ButtonWidget } from '../Button/ButtonWidget'
 import { TabsField } from '../Tabs'
 import { HeadingField } from '../Heading/HeadingField'
 
-/** Semantic color for active tab styling — maps to Appian's primary brand color */
+/** Active tab color */
 const ACTIVE_TAB_COLOR = 'ACCENT'
 
 /**
  * Record action button configuration.
- * Maps to SAIL's related action buttons shown in the record header.
  */
 export interface RecordAction {
   /** Button label */
@@ -24,7 +23,6 @@ export interface RecordAction {
 
 /**
  * Record view tab configuration.
- * Maps to SAIL's record view tabs (Summary, Addresses, etc.)
  */
 export interface RecordViewTab {
   /** Tab label */
@@ -78,10 +76,7 @@ export interface RecordViewProps {
 /** Maximum number of action buttons shown before overflow */
 const MAX_VISIBLE_ACTIONS = 3
 
-/**
- * RecordActions — renders visible action buttons with an overflow dropdown
- * when there are more than MAX_VISIBLE_ACTIONS.
- */
+/** Renders record action buttons with overflow dropdown. */
 const RecordActions: React.FC<{ actions: RecordAction[] }> = ({ actions }) => {
   const visibleActions = actions.slice(0, MAX_VISIBLE_ACTIONS)
   const overflowActions = actions.slice(MAX_VISIBLE_ACTIONS)
@@ -137,14 +132,7 @@ const RecordActions: React.FC<{ actions: RecordAction[] }> = ({ actions }) => {
 
 /**
  * RecordView Template
- *
- * A page-level template for prototyping Appian record views.
- * Provides the full page shell: site sidebar nav on the left,
- * record header (title + actions + view tabs) on the right,
- * and a content slot for UXDs to fill in with their specific view content.
- *
- * Maps to SAIL's a!navigationLayout (SIDEBAR) wrapping a!headerContentLayout
- * with record views and related actions.
+ * Maps to SAIL's a!navigationLayout (SIDEBAR) wrapping a!headerContentLayout.
  */
 export const RecordView: React.FC<RecordViewProps> = ({
   // Site nav
@@ -217,7 +205,7 @@ export const RecordView: React.FC<RecordViewProps> = ({
           </div>
         )}
 
-        {/* Content slot — used when views don't provide their own content */}
+        {/* Content slot */}
         <div className="flex-1 overflow-y-auto bg-gray-50">
           {children || (
             <div className="p-6 text-gray-400 text-sm">

--- a/src/components/RecordView/RecordView.tsx
+++ b/src/components/RecordView/RecordView.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { SiteNav } from '../SiteNav'
 import type { SiteNavPage } from '../SiteNav'
+import type { SAILSemanticColor } from '../../types/sail'
 import { ButtonArrayLayout } from '../Button/ButtonArrayLayout'
 import { ButtonWidget } from '../Button/ButtonWidget'
 import { TabsField } from '../Tabs'
+import { HeadingField } from '../Heading/HeadingField'
 
 /** Semantic color for active tab styling — maps to Appian's primary brand color */
 const ACTIVE_TAB_COLOR = 'ACCENT'
@@ -53,7 +56,7 @@ export interface RecordViewProps {
   /** Appian logo path */
   appianLogoSrc?: string
   /** Highlight color for selected nav item (passed to SiteNav) */
-  highlightColor?: string
+  highlightColor?: SAILSemanticColor | string
 
   /* --- Record header props --- */
   /** Record title (e.g. "REC-001 | Sample Record") */
@@ -80,23 +83,8 @@ const MAX_VISIBLE_ACTIONS = 3
  * when there are more than MAX_VISIBLE_ACTIONS.
  */
 const RecordActions: React.FC<{ actions: RecordAction[] }> = ({ actions }) => {
-  const [overflowOpen, setOverflowOpen] = React.useState(false)
-  const overflowRef = React.useRef<HTMLDivElement>(null)
-
   const visibleActions = actions.slice(0, MAX_VISIBLE_ACTIONS)
   const overflowActions = actions.slice(MAX_VISIBLE_ACTIONS)
-
-  // Close dropdown when clicking outside
-  React.useEffect(() => {
-    if (!overflowOpen) return
-    const handleClickOutside = (e: MouseEvent) => {
-      if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) {
-        setOverflowOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [overflowOpen])
 
   return (
     <div className="flex items-center gap-1 shrink-0">
@@ -111,33 +99,37 @@ const RecordActions: React.FC<{ actions: RecordAction[] }> = ({ actions }) => {
         marginBelow="NONE"
       />
       {overflowActions.length > 0 && (
-        <div className="relative" ref={overflowRef}>
-          <ButtonWidget
-            icon="ellipsis"
-            style="OUTLINE"
-            color="ACCENT"
-            size="SMALL"
-            accessibilityText="More actions"
-            tooltip="More actions"
-            onClick={() => setOverflowOpen((prev) => !prev)}
-          />
-          {overflowOpen && (
-            <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-sm shadow-lg z-10 min-w-48">
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <div>
+              <ButtonWidget
+                icon="ellipsis"
+                style="OUTLINE"
+                color="ACCENT"
+                size="SMALL"
+                accessibilityText="More actions"
+                tooltip="More actions"
+              />
+            </div>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              className="bg-white border border-gray-200 rounded-sm shadow-lg z-10 min-w-48"
+              align="end"
+              sideOffset={4}
+            >
               {overflowActions.map((action) => (
-                <button
+                <DropdownMenu.Item
                   key={action.label}
-                  onClick={() => {
-                    action.onClick?.()
-                    setOverflowOpen(false)
-                  }}
-                  className="block w-full text-left px-4 py-2.5 text-sm text-gray-800 hover:bg-gray-100 transition-colors cursor-pointer"
+                  onSelect={() => action.onClick?.()}
+                  className="block w-full text-left px-4 py-2.5 text-sm text-gray-800 hover:bg-gray-100 transition-colors cursor-pointer outline-none data-[highlighted]:bg-gray-100"
                 >
                   {action.label}
-                </button>
+                </DropdownMenu.Item>
               ))}
-            </div>
-          )}
-        </div>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
       )}
     </div>
   )
@@ -191,9 +183,9 @@ export const RecordView: React.FC<RecordViewProps> = ({
       <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {/* Record header: title + actions */}
         <div className="flex items-center justify-between px-6 pt-3 pb-2 bg-gray-50 shrink-0">
-          <h1 className="text-3xl font-semibold text-gray-900 truncate mr-4">
-            {recordTitle}
-          </h1>
+          <div className="truncate mr-4">
+            <HeadingField text={recordTitle} size="LARGE_PLUS" marginBelow="NONE" fontWeight="SEMI_BOLD" />
+          </div>
 
           {recordActions.length > 0 && (
             <RecordActions actions={recordActions} />

--- a/src/components/RecordView/index.ts
+++ b/src/components/RecordView/index.ts
@@ -1,0 +1,6 @@
+export { RecordView } from './RecordView'
+export type {
+  RecordViewProps,
+  RecordAction,
+  RecordViewTab,
+} from './RecordView'

--- a/src/components/SiteNav/SiteNav.stories.tsx
+++ b/src/components/SiteNav/SiteNav.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { SiteNav } from './SiteNav'
+import type { SiteNavPage } from './SiteNav'
+import {
+  Home,
+  List,
+  Inbox,
+  FolderOpen,
+  FileText,
+  BarChart3,
+  Search,
+  MessagesSquare,
+} from 'lucide-react'
+
+const meta = {
+  title: 'Components/SiteNav',
+  component: SiteNav,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh', display: 'flex' }}>
+        <Story />
+        <div style={{ flex: 1, background: '#f5f5f5', padding: '1rem' }}>
+          <p style={{ color: '#666' }}>Page content area</p>
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SiteNav>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const sitePages: SiteNavPage[] = [
+  { label: 'Home', icon: Home },
+  { label: 'Records', icon: List, isSelected: true },
+  { label: 'Inbox', icon: Inbox, badge: '(3)' },
+  {
+    label: 'Directory',
+    icon: FolderOpen,
+    isGroup: true,
+    children: [
+      { label: 'People' },
+      { label: 'Teams' },
+    ],
+  },
+  { label: 'Reports', icon: BarChart3 },
+  { label: 'Search', icon: Search },
+  { label: 'Chat', icon: MessagesSquare },
+]
+
+export const Default: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    userName: 'Jane Doe',
+  },
+}
+
+export const Collapsed: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    collapsed: true,
+    userName: 'Jane Doe',
+  },
+}
+
+export const WithGroupExpanded: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: [
+      { label: 'Home', icon: Home },
+      { label: 'Records', icon: List },
+      {
+        label: 'Directory',
+        icon: FolderOpen,
+        isGroup: true,
+        children: [
+          { label: 'People', isSelected: true },
+          { label: 'Teams' },
+        ],
+      },
+      { label: 'Reports', icon: BarChart3 },
+    ],
+    userName: 'Jane Doe',
+  },
+}
+
+export const MinimalPages: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: [
+      { label: 'Home', icon: Home, isSelected: true },
+      { label: 'Documents', icon: FileText },
+    ],
+    userName: 'Alex Brown',
+  },
+}
+
+
+export const Hidden: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    showNavigation: false,
+    userName: 'Jane Doe',
+  },
+}

--- a/src/components/SiteNav/SiteNav.tsx
+++ b/src/components/SiteNav/SiteNav.tsx
@@ -5,6 +5,8 @@ import {
   LayoutGrid,
   type LucideIcon,
 } from 'lucide-react'
+import { ImageField } from '../Image/ImageField'
+import type { SAILSemanticColor } from '../../types/sail'
 
 /**
  * Represents a single page/tab in the site navigation.
@@ -46,8 +48,8 @@ export interface SiteNavProps {
   userName?: string
   /** Path to Appian logo image */
   appianLogoSrc?: string
-  /** Background color for the selected/highlighted page. Accepts hex color string. Default: "#DFFCD2" (light green) */
-  highlightColor?: string
+  /** Background color for the selected/highlighted page. Accepts hex or semantic color. Default: "POSITIVE" */
+  highlightColor?: SAILSemanticColor | string
 }
 
 
@@ -65,11 +67,23 @@ export const SiteNav: React.FC<SiteNavProps> = ({
   showNavigation = true,
   userName,
   appianLogoSrc = 'images/icon-appian-header.png',
-  highlightColor = '#DFFCD2',
+  highlightColor = 'POSITIVE',
 }) => {
   const [internalCollapsed, setInternalCollapsed] = React.useState(false)
 
   const isCollapsed = controlledCollapsed ?? internalCollapsed
+
+  // Resolve highlight color: semantic → Tailwind class, hex → inline style
+  const semanticHighlightMap: Record<SAILSemanticColor, string> = {
+    ACCENT: 'bg-blue-100',
+    POSITIVE: 'bg-green-100',
+    NEGATIVE: 'bg-red-100',
+    SECONDARY: 'bg-gray-100',
+    STANDARD: 'bg-gray-200',
+  }
+  const isHexHighlight = highlightColor.startsWith('#')
+  const highlightClass = !isHexHighlight ? (semanticHighlightMap[highlightColor as SAILSemanticColor] || semanticHighlightMap.POSITIVE) : ''
+  const highlightStyle = isHexHighlight ? { backgroundColor: highlightColor } : undefined
 
   const userInitials = userName
     ? userName.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)
@@ -96,7 +110,7 @@ export const SiteNav: React.FC<SiteNavProps> = ({
             <img
               src={appianLogoSrc}
               alt="Appian"
-              className="h-8 w-auto"
+              className="h-8 w-auto -mb-0.5"
             />
             {/* Waffle menu — decorative in prototype */}
             <button
@@ -133,7 +147,8 @@ export const SiteNav: React.FC<SiteNavProps> = ({
               key={page.label}
               page={page}
               isCollapsed={isCollapsed}
-              highlightColor={highlightColor}
+              highlightClass={highlightClass}
+              highlightStyle={highlightStyle}
             />
           ))}
         </ul>
@@ -152,12 +167,16 @@ export const SiteNav: React.FC<SiteNavProps> = ({
                 <LayoutGrid className="w-5 h-5" />
               </button>
 
-              <div
-                className="flex items-center justify-center w-10 h-10 rounded-full border border-gray-300 text-gray-700 text-sm font-medium"
-                title={userName || userInitials}
-              >
-                {userInitials}
-              </div>
+              <ImageField
+                images={[{
+                  imageType: 'user' as const,
+                  user: { name: userName || userInitials, initials: userInitials },
+                  altText: userName || userInitials,
+                }]}
+                style="AVATAR"
+                size="ICON_PLUS"
+                marginBelow="NONE"
+              />
 
               <button
                 onClick={toggleCollapse}
@@ -170,12 +189,16 @@ export const SiteNav: React.FC<SiteNavProps> = ({
             </div>
           ) : (
               <div className="flex items-center pl-4 py-4">
-                <div
-                  className="flex items-center justify-center w-10 h-10 rounded-full border border-gray-300 text-gray-700 text-sm font-medium shrink-0"
-                  title={userName || userInitials}
-                >
-                  {userInitials}
-                </div>
+                <ImageField
+                  images={[{
+                    imageType: 'user' as const,
+                    user: { name: userName || userInitials, initials: userInitials },
+                    altText: userName || userInitials,
+                  }]}
+                  style="AVATAR"
+                  size="ICON_PLUS"
+                  marginBelow="NONE"
+                />
                 <span className="ml-3 text-sm font-medium text-gray-800 truncate flex-1">
                   {userName || userInitials}
                 </span>
@@ -196,14 +219,14 @@ export const SiteNav: React.FC<SiteNavProps> = ({
 
 /**
  * SiteNavItem — renders a single navigation item (page or group).
- * Uses HighlightColorContext for the selected background color.
  */
 const SiteNavItem: React.FC<{
   page: SiteNavPage
   isCollapsed: boolean
-  highlightColor: string
+  highlightClass: string
+  highlightStyle?: React.CSSProperties
   depth?: number
-}> = ({ page, isCollapsed, highlightColor, depth = 0 }) => {
+}> = ({ page, isCollapsed, highlightClass, highlightStyle, depth = 0 }) => {
   const [expanded, setExpanded] = React.useState(
     // Auto-expand if any child is selected
     page.children?.some((c) => c.isSelected) ?? false
@@ -229,12 +252,12 @@ const SiteNavItem: React.FC<{
           ${isCollapsed ? 'justify-center px-2' : 'px-3'}
           ${depth > 0 ? 'py-2' : 'py-3'}
           rounded-sm
-          ${page.isSelected ? 'font-bold' : 'font-normal'}
+          ${page.isSelected ? `font-bold ${highlightClass}` : 'font-normal'}
           text-gray-800 hover:bg-gray-100
         `}
         style={
           page.isSelected
-            ? { backgroundColor: highlightColor }
+            ? highlightStyle
             : undefined
         }
         aria-current={page.isSelected ? 'page' : undefined}
@@ -279,7 +302,8 @@ const SiteNavItem: React.FC<{
               key={child.label}
               page={child}
               isCollapsed={isCollapsed}
-              highlightColor={highlightColor}
+              highlightClass={highlightClass}
+              highlightStyle={highlightStyle}
               depth={depth + 1}
             />
           ))}

--- a/src/components/SiteNav/SiteNav.tsx
+++ b/src/components/SiteNav/SiteNav.tsx
@@ -73,7 +73,7 @@ export const SiteNav: React.FC<SiteNavProps> = ({
 
   const isCollapsed = controlledCollapsed ?? internalCollapsed
 
-  // Resolve highlight color: semantic → Tailwind class, hex → inline style
+  // Highlight color mappings
   const semanticHighlightMap: Record<SAILSemanticColor, string> = {
     ACCENT: 'bg-blue-100',
     POSITIVE: 'bg-green-100',
@@ -104,7 +104,7 @@ export const SiteNav: React.FC<SiteNavProps> = ({
         }`}
         aria-label="Site navigation"
       >
-        {/* Top: Appian logo + waffle menu (expanded) or just Appian logo (collapsed) */}
+        {/* Logo + waffle menu */}
         {!isCollapsed ? (
           <div className="flex items-center justify-between px-4 pt-4 pb-6 shrink-0">
             <img
@@ -112,7 +112,7 @@ export const SiteNav: React.FC<SiteNavProps> = ({
               alt="Appian"
               className="h-8 w-auto -mb-0.5"
             />
-            {/* Waffle menu — decorative in prototype */}
+            {/* Waffle menu (decorative) */}
             <button
               className="flex items-center justify-center w-8 h-8 text-gray-700 hover:bg-gray-100 rounded-sm transition-colors"
               aria-label="Navigation menu"
@@ -156,9 +156,8 @@ export const SiteNav: React.FC<SiteNavProps> = ({
         {/* Bottom section */}
         <div className="flex flex-col shrink-0">
           {isCollapsed ? (
-            /* Collapsed: stacked vertically — waffle, avatar, collapse toggle */
             <div className="flex flex-col items-center gap-3 py-4">
-              {/* Waffle menu — decorative in prototype */}
+              {/* Waffle menu (decorative) */}
               <button
                 className="flex items-center justify-center w-8 h-8 text-gray-700 hover:bg-gray-100 rounded-sm transition-colors"
                 aria-label="Navigation menu"

--- a/src/components/SiteNav/SiteNav.tsx
+++ b/src/components/SiteNav/SiteNav.tsx
@@ -1,0 +1,290 @@
+import * as React from 'react'
+import {
+  ChevronRight,
+  ChevronLeft,
+  LayoutGrid,
+  type LucideIcon,
+} from 'lucide-react'
+
+/**
+ * Represents a single page/tab in the site navigation.
+ * Maps to SAIL's NavigationNode / NavigationMenuTab types.
+ */
+export interface SiteNavPage {
+  /** Display text for the page (maps to NavigationNode.name / NavigationMenuTab.label) */
+  label: string
+  /** Lucide icon component (maps to NavigationNode.icon / NavigationMenuTab.iconFriendlyName) */
+  icon?: LucideIcon
+  /** Whether this page is currently active (maps to NavigationMenuTab.isSelected) */
+  isSelected?: boolean
+  /** Whether this is a group with children (maps to NavigationNode.isGroup) */
+  isGroup?: boolean
+  /** Sub-pages for grouped navigation (maps to NavigationNode.children) */
+  children?: SiteNavPage[]
+  /** Optional badge text, e.g. "(1)" for unread count */
+  badge?: string
+  /** Callback when page is clicked */
+  onClick?: () => void
+}
+
+/**
+ * Props for the SiteNav component.
+ * Maps to SAIL's a!navigationLayout with primaryNavLayoutType="SIDEBAR".
+ */
+export interface SiteNavProps {
+  /** Site/solution display name (maps to NavigationLayout.displayName) */
+  displayName?: string
+  /** Array of site pages (maps to NavigationLayout.tabs / NavigationNode[]) */
+  pages: SiteNavPage[]
+  /** Controlled collapsed state */
+  collapsed?: boolean
+  /** Callback when collapse toggle is clicked */
+  onCollapseToggle?: (collapsed: boolean) => void
+  /** Whether to show the navigation (maps to NavigationLayout.showNavigation) */
+  showNavigation?: boolean
+  /** User full name — initials are derived automatically */
+  userName?: string
+  /** Path to Appian logo image */
+  appianLogoSrc?: string
+  /** Background color for the selected/highlighted page. Accepts hex color string. Default: "#DFFCD2" (light green) */
+  highlightColor?: string
+}
+
+
+/**
+ * SiteNav Component
+ *
+ * Renders the sidebar navigation for an Appian site.
+ * Maps to SAIL's a!navigationLayout with primaryNavLayoutType="SIDEBAR".
+ */
+export const SiteNav: React.FC<SiteNavProps> = ({
+  displayName,
+  pages,
+  collapsed: controlledCollapsed,
+  onCollapseToggle,
+  showNavigation = true,
+  userName,
+  appianLogoSrc = 'images/icon-appian-header.png',
+  highlightColor = '#DFFCD2',
+}) => {
+  const [internalCollapsed, setInternalCollapsed] = React.useState(false)
+
+  const isCollapsed = controlledCollapsed ?? internalCollapsed
+
+  const userInitials = userName
+    ? userName.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)
+    : 'U'
+
+  const toggleCollapse = () => {
+    const next = !isCollapsed
+    setInternalCollapsed(next)
+    onCollapseToggle?.(next)
+  }
+
+  if (!showNavigation) return null
+
+  return (
+      <nav
+        className={`flex flex-col h-full bg-white transition-all duration-200 shrink-0 ${
+          isCollapsed ? 'w-16' : 'w-[240px]'
+        }`}
+        aria-label="Site navigation"
+      >
+        {/* Top: Appian logo + waffle menu (expanded) or just Appian logo (collapsed) */}
+        {!isCollapsed ? (
+          <div className="flex items-center justify-between px-4 pt-4 pb-6 shrink-0">
+            <img
+              src={appianLogoSrc}
+              alt="Appian"
+              className="h-8 w-auto"
+            />
+            {/* Waffle menu — decorative in prototype */}
+            <button
+              className="flex items-center justify-center w-8 h-8 text-gray-700 hover:bg-gray-100 rounded-sm transition-colors"
+              aria-label="Navigation menu"
+              title="Navigation menu"
+            >
+              <LayoutGrid className="w-5 h-5" />
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center pt-3 pb-6 shrink-0">
+            <img
+              src={appianLogoSrc}
+              alt="Appian"
+              className="h-4 w-auto"
+            />
+          </div>
+        )}
+
+        {/* Site name */}
+        {!isCollapsed && displayName && (
+          <div className="px-4 pb-3">
+            <span className="text-lg font-semibold text-gray-900 leading-tight whitespace-pre-line">
+              {displayName}
+            </span>
+          </div>
+        )}
+
+        {/* Page list */}
+        <ul className="flex-1 list-none m-0 px-2 py-0 overflow-y-auto" role="list">
+          {pages.map((page) => (
+            <SiteNavItem
+              key={page.label}
+              page={page}
+              isCollapsed={isCollapsed}
+              highlightColor={highlightColor}
+            />
+          ))}
+        </ul>
+
+        {/* Bottom section */}
+        <div className="flex flex-col shrink-0">
+          {isCollapsed ? (
+            /* Collapsed: stacked vertically — waffle, avatar, collapse toggle */
+            <div className="flex flex-col items-center gap-3 py-4">
+              {/* Waffle menu — decorative in prototype */}
+              <button
+                className="flex items-center justify-center w-8 h-8 text-gray-700 hover:bg-gray-100 rounded-sm transition-colors"
+                aria-label="Navigation menu"
+                title="Navigation menu"
+              >
+                <LayoutGrid className="w-5 h-5" />
+              </button>
+
+              <div
+                className="flex items-center justify-center w-10 h-10 rounded-full border border-gray-300 text-gray-700 text-sm font-medium"
+                title={userName || userInitials}
+              >
+                {userInitials}
+              </div>
+
+              <button
+                onClick={toggleCollapse}
+                className="flex items-center justify-center w-8 h-8 rounded bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors"
+                aria-label="Expand navigation"
+                title="Expand navigation"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          ) : (
+              <div className="flex items-center pl-4 py-4">
+                <div
+                  className="flex items-center justify-center w-10 h-10 rounded-full border border-gray-300 text-gray-700 text-sm font-medium shrink-0"
+                  title={userName || userInitials}
+                >
+                  {userInitials}
+                </div>
+                <span className="ml-3 text-sm font-medium text-gray-800 truncate flex-1">
+                  {userName || userInitials}
+                </span>
+                <button
+                  onClick={toggleCollapse}
+                  className="flex items-center justify-center w-8 h-8 rounded-l bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors shrink-0"
+                  aria-label="Collapse navigation"
+                  title="Collapse navigation"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </button>
+              </div>
+          )}
+        </div>
+      </nav>
+  )
+}
+
+/**
+ * SiteNavItem — renders a single navigation item (page or group).
+ * Uses HighlightColorContext for the selected background color.
+ */
+const SiteNavItem: React.FC<{
+  page: SiteNavPage
+  isCollapsed: boolean
+  highlightColor: string
+  depth?: number
+}> = ({ page, isCollapsed, highlightColor, depth = 0 }) => {
+  const [expanded, setExpanded] = React.useState(
+    // Auto-expand if any child is selected
+    page.children?.some((c) => c.isSelected) ?? false
+  )
+
+  const IconComponent = page.icon
+  const hasChildren = page.isGroup || (page.children && page.children.length > 0)
+
+  const handleClick = () => {
+    if (hasChildren) {
+      setExpanded((prev) => !prev)
+    }
+    page.onClick?.()
+  }
+
+  return (
+    <li className="list-none mb-1">
+      <button
+        onClick={handleClick}
+        title={isCollapsed ? page.label : undefined}
+        className={`
+          flex items-center w-full text-left transition-colors
+          ${isCollapsed ? 'justify-center px-2' : 'px-3'}
+          ${depth > 0 ? 'py-2' : 'py-3'}
+          rounded-sm
+          ${page.isSelected ? 'font-bold' : 'font-normal'}
+          text-gray-800 hover:bg-gray-100
+        `}
+        style={
+          page.isSelected
+            ? { backgroundColor: highlightColor }
+            : undefined
+        }
+        aria-current={page.isSelected ? 'page' : undefined}
+      >
+        {/* Icon */}
+        {IconComponent && (
+          <span className={`shrink-0 ${isCollapsed ? '' : 'mr-3'}`}>
+            <IconComponent className="w-5 h-5 text-gray-700" />
+          </span>
+        )}
+
+        {/* Indentation for children without icons */}
+        {!IconComponent && depth > 0 && !isCollapsed && (
+          <span className="w-5 mr-3 shrink-0" />
+        )}
+
+        {/* Label + badge */}
+        {!isCollapsed && (
+          <span className="flex-1 truncate text-sm text-gray-800">
+            {page.label}
+            {page.badge && (
+              <span className="ml-1 text-gray-500">{page.badge}</span>
+            )}
+          </span>
+        )}
+
+        {/* Group chevron */}
+        {hasChildren && !isCollapsed && (
+          <ChevronRight
+            className={`w-4 h-4 text-gray-400 shrink-0 transition-transform ${
+              expanded ? 'rotate-90' : ''
+            }`}
+          />
+        )}
+      </button>
+
+      {/* Children */}
+      {hasChildren && expanded && !isCollapsed && page.children && (
+        <ul className="list-none m-0 p-0 pl-4" role="group">
+          {page.children.map((child) => (
+            <SiteNavItem
+              key={child.label}
+              page={child}
+              isCollapsed={isCollapsed}
+              highlightColor={highlightColor}
+              depth={depth + 1}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}

--- a/src/components/SiteNav/index.ts
+++ b/src/components/SiteNav/index.ts
@@ -1,0 +1,2 @@
+export { SiteNav } from './SiteNav'
+export type { SiteNavProps, SiteNavPage } from './SiteNav'

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -12,7 +12,8 @@ const meta = {
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
   argTypes: {
-    size: { control: 'select', options: ['SMALL', 'STANDARD', 'LARGE'] },
+    variant: { control: 'select', options: ['UNDERLINE', 'PILL'] },
+    size: { control: 'select', options: ['SMALL', 'STANDARD', 'MEDIUM', 'LARGE'] },
     color: { control: 'text' },
     orientation: { control: 'select', options: ['HORIZONTAL', 'VERTICAL'] },
     activationMode: { control: 'select', options: ['AUTOMATIC', 'MANUAL'] },
@@ -259,5 +260,33 @@ export const ManualActivation: Story = {
     ],
     defaultValue: 'manual1',
     activationMode: 'MANUAL',
+  },
+}
+
+export const PillVariant: Story = {
+  args: {
+    tabs: [
+      { value: 'summary', label: 'Summary', content: <p className="text-base text-gray-700">Summary view content.</p> },
+      { value: 'details', label: 'Details', content: <p className="text-base text-gray-700">Details view content.</p> },
+      { value: 'activity', label: 'Activity', content: <p className="text-base text-gray-700">Activity view content.</p> },
+      { value: 'documents', label: 'Documents', content: <p className="text-base text-gray-700">Documents view content.</p> },
+      { value: 'history', label: 'History', content: <p className="text-base text-gray-700">History view content.</p> },
+    ],
+    defaultValue: 'summary',
+    variant: 'PILL',
+    size: 'SMALL',
+  },
+}
+
+export const PillVariantCustomColor: Story = {
+  args: {
+    tabs: [
+      { value: 'tab1', label: 'Tab One', content: <p className="text-base text-gray-700">Custom color pill tab.</p> },
+      { value: 'tab2', label: 'Tab Two', content: <p className="text-base text-gray-700">Custom color pill tab.</p> },
+    ],
+    defaultValue: 'tab1',
+    variant: 'PILL',
+    size: 'SMALL',
+    color: '#9333EA',
   },
 }

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -263,7 +263,7 @@ export const ManualActivation: Story = {
   },
 }
 
-export const PillVariant: Story = {
+export const Pill: Story = {
   args: {
     tabs: [
       { value: 'summary', label: 'Summary', content: <p className="text-base text-gray-700">Summary view content.</p> },
@@ -278,7 +278,7 @@ export const PillVariant: Story = {
   },
 }
 
-export const PillVariantCustomColor: Story = {
+export const PillCustomColor: Story = {
   args: {
     tabs: [
       { value: 'tab1', label: 'Tab One', content: <p className="text-base text-gray-700">Custom color pill tab.</p> },

--- a/src/components/Tabs/TabsField.tsx
+++ b/src/components/Tabs/TabsField.tsx
@@ -77,7 +77,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
   // Visibility control
   if (!showWhen) return null
 
-  // Track active tab for pill variant styling (works for both controlled and uncontrolled)
+  // Track active tab
   const [internalValue, setInternalValue] = React.useState(value || defaultValue || tabs[0]?.value)
   const activeValue = value ?? internalValue
 
@@ -119,7 +119,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
     marginBottomMap[marginBelow]
   ].filter(Boolean).join(' ')
 
-  // Semantic color → Tailwind class mappings (follows ButtonWidget pattern)
+  // Color mappings
   const semanticBgMap: Record<SAILSemanticColor, string> = {
     ACCENT: 'bg-blue-500',
     POSITIVE: 'bg-green-700',
@@ -196,14 +196,16 @@ export const TabsField: React.FC<TabsFieldProps> = ({
                   {tab.label}
                   {activeValue === tab.value && (
                     <svg
-                      className="absolute left-1/2 -translate-x-1/2 -bottom-1.5 w-3 h-1.5"
+                      className={[
+                        'absolute left-1/2 -translate-x-1/2 -bottom-1.5 w-3 h-1.5',
+                        !isHexColor ? (semanticTextMap[color as SAILSemanticColor] || semanticTextMap.ACCENT) : ''
+                      ].filter(Boolean).join(' ')}
                       viewBox="0 0 12 6"
                       aria-hidden="true"
                     >
                       <polygon
                         points="6,6 0,0 12,0"
-                        className={isHexColor ? undefined : (semanticBgMap[color as SAILSemanticColor] || semanticBgMap.ACCENT).replace('bg-', 'fill-')}
-                        fill={isHexColor ? color : undefined}
+                        fill={isHexColor ? color : 'currentColor'}
                       />
                     </svg>
                   )}

--- a/src/components/Tabs/TabsField.tsx
+++ b/src/components/Tabs/TabsField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as Tabs from '@radix-ui/react-tabs'
-import type { SAILMarginSize, SAILSize } from '../../types/sail'
+import type { SAILMarginSize, SAILSize, SAILSemanticColor } from '../../types/sail'
 
 /**
  * Individual tab configuration
@@ -54,7 +54,7 @@ export interface TabsFieldProps {
   /** Space added below component */
   marginBelow?: SAILMarginSize
   /** Color scheme for active tabs (hex or semantic) */
-  color?: "ACCENT" | "POSITIVE" | "NEGATIVE" | "SECONDARY" | string
+  color?: SAILSemanticColor | string
   /** Activation mode - whether tabs activate on focus or click */
   activationMode?: "AUTOMATIC" | "MANUAL"
 }
@@ -119,14 +119,22 @@ export const TabsField: React.FC<TabsFieldProps> = ({
     marginBottomMap[marginBelow]
   ].filter(Boolean).join(' ')
 
-  // Resolve active color to a CSS value
-  const semanticColorMap: Record<string, string> = {
-    ACCENT: '#2322F0',
-    POSITIVE: '#117C00',
-    NEGATIVE: '#9F0019',
-    SECONDARY: '#374151',
+  // Semantic color → Tailwind class mappings (follows ButtonWidget pattern)
+  const semanticBgMap: Record<SAILSemanticColor, string> = {
+    ACCENT: 'bg-blue-500',
+    POSITIVE: 'bg-green-700',
+    NEGATIVE: 'bg-red-700',
+    SECONDARY: 'bg-gray-700',
+    STANDARD: 'bg-gray-900',
   }
-  const activeColor = color.startsWith('#') ? color : (semanticColorMap[color] || semanticColorMap.ACCENT)
+  const semanticTextMap: Record<SAILSemanticColor, string> = {
+    ACCENT: 'text-blue-500',
+    POSITIVE: 'text-green-700',
+    NEGATIVE: 'text-red-700',
+    SECONDARY: 'text-gray-700',
+    STANDARD: 'text-gray-900',
+  }
+  const isHexColor = color.startsWith('#')
 
   // List classes based on orientation and variant
   const listClasses = variant === "PILL"
@@ -170,14 +178,19 @@ export const TabsField: React.FC<TabsFieldProps> = ({
                     'group relative',
                     sizeMap[size],
                     'rounded-sm transition-colors whitespace-nowrap cursor-pointer select-none outline-none border-0',
-                    activeValue === tab.value ? 'font-medium' : 'hover:bg-gray-100',
+                    activeValue === tab.value
+                      ? (isHexColor ? '' : `${semanticBgMap[color as SAILSemanticColor] || semanticBgMap.ACCENT} text-white`)
+                      : (isHexColor ? '' : `${semanticTextMap[color as SAILSemanticColor] || semanticTextMap.ACCENT}`),
+                    activeValue !== tab.value ? 'hover:bg-gray-100' : '',
                     'disabled:opacity-50 disabled:cursor-not-allowed',
                     'focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2'
-                  ].join(' ')}
+                  ].filter(Boolean).join(' ')}
                   style={
-                    activeValue === tab.value
-                      ? { backgroundColor: activeColor, color: '#ffffff' }
-                      : { color: activeColor }
+                    isHexColor
+                      ? activeValue === tab.value
+                        ? { backgroundColor: color, color: '#ffffff' }
+                        : { color: color }
+                      : undefined
                   }
                 >
                   {tab.label}
@@ -187,7 +200,11 @@ export const TabsField: React.FC<TabsFieldProps> = ({
                       viewBox="0 0 12 6"
                       aria-hidden="true"
                     >
-                      <polygon points="6,6 0,0 12,0" fill={activeColor} />
+                      <polygon
+                        points="6,6 0,0 12,0"
+                        className={isHexColor ? undefined : (semanticBgMap[color as SAILSemanticColor] || semanticBgMap.ACCENT).replace('bg-', 'fill-')}
+                        fill={isHexColor ? color : undefined}
+                      />
                     </svg>
                   )}
                 </Tabs.Trigger>

--- a/src/components/Tabs/TabsField.tsx
+++ b/src/components/Tabs/TabsField.tsx
@@ -17,6 +17,13 @@ export interface TabItem {
 }
 
 /**
+ * Visual variant for tab styling
+ * - UNDERLINE: Standard tabs with an underline indicator (default)
+ * - PILL: Filled background on active tab with a downward caret indicator
+ */
+export type TabsVariant = "UNDERLINE" | "PILL"
+
+/**
  * Displays a set of layered sections of content (tab panels) that are displayed one at a time
  * Inspired by SAIL form field patterns (not an official SAIL component)
  *
@@ -32,7 +39,9 @@ export interface TabsFieldProps {
   defaultValue?: string
   /** Callback when active tab changes */
   onValueChange?: (value: string) => void
-  /** Orientation of the tabs */
+  /** Visual variant for tab styling */
+  variant?: TabsVariant
+  /** Orientation of the tabs (only applies to UNDERLINE variant) */
   orientation?: "HORIZONTAL" | "VERTICAL"
   /** Size of the tab triggers */
   size?: SAILSize
@@ -55,6 +64,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
   value,
   defaultValue,
   onValueChange,
+  variant = "UNDERLINE",
   orientation = "HORIZONTAL",
   size = "STANDARD",
   loop = true,
@@ -66,6 +76,15 @@ export const TabsField: React.FC<TabsFieldProps> = ({
 }) => {
   // Visibility control
   if (!showWhen) return null
+
+  // Track active tab for pill variant styling (works for both controlled and uncontrolled)
+  const [internalValue, setInternalValue] = React.useState(value || defaultValue || tabs[0]?.value)
+  const activeValue = value ?? internalValue
+
+  const handleValueChange = (val: string) => {
+    setInternalValue(val)
+    onValueChange?.(val)
+  }
 
   // Margin mappings
   const marginMap: Record<SAILMarginSize, string> = {
@@ -100,10 +119,21 @@ export const TabsField: React.FC<TabsFieldProps> = ({
     marginBottomMap[marginBelow]
   ].filter(Boolean).join(' ')
 
-  // List classes based on orientation
-  const listClasses = orientation === "VERTICAL" 
-    ? "flex flex-col"
-    : "flex border-b border-gray-200"
+  // Resolve active color to a CSS value
+  const semanticColorMap: Record<string, string> = {
+    ACCENT: '#2322F0',
+    POSITIVE: '#117C00',
+    NEGATIVE: '#9F0019',
+    SECONDARY: '#374151',
+  }
+  const activeColor = color.startsWith('#') ? color : (semanticColorMap[color] || semanticColorMap.ACCENT)
+
+  // List classes based on orientation and variant
+  const listClasses = variant === "PILL"
+    ? "flex items-end gap-1"
+    : orientation === "VERTICAL"
+      ? "flex flex-col"
+      : "flex border-b border-gray-200"
 
   // Content classes based on orientation
   const contentClasses = orientation === "VERTICAL"
@@ -120,7 +150,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
       <Tabs.Root
         value={value}
         defaultValue={defaultValue || tabs[0]?.value}
-        onValueChange={onValueChange}
+        onValueChange={handleValueChange}
         orientation={orientation.toLowerCase() as "horizontal" | "vertical"}
         activationMode={activationMode.toLowerCase() as "automatic" | "manual"}
         className={rootClasses}
@@ -129,31 +159,66 @@ export const TabsField: React.FC<TabsFieldProps> = ({
           className={listClasses}
           loop={loop}
         >
-          {tabs.map((tab) => (
-            <Tabs.Trigger
-              key={tab.value}
-              value={tab.value}
-              disabled={tab.disabled}
-              className={[
-                sizeMap[size],
-                'flex-1 bg-white text-gray-700 border-0 cursor-default select-none',
-                'items-center justify-center outline-none transition-colors hover:text-blue-500',
-                // Active state with underline shadow for horizontal, left border for vertical
-                orientation === "HORIZONTAL"
-                  ? 'data-[state=active]:text-blue-500 data-[state=active]:shadow-[inset_0_-2px_0_0] data-[state=active]:shadow-current'
-                  : 'data-[state=active]:text-blue-500 data-[state=active]:shadow-[inset_2px_0_0_0] data-[state=active]:shadow-current',
-                'disabled:opacity-50 disabled:cursor-not-allowed',
-                'focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-blue-500'
-              ].filter(Boolean).join(' ')}
-              style={
-                color.startsWith('#') && value === tab.value
-                  ? { color: color }
-                  : undefined
-              }
-            >
-              {tab.label}
-            </Tabs.Trigger>
-          ))}
+          {tabs.map((tab) => {
+            if (variant === "PILL") {
+              return (
+                <Tabs.Trigger
+                  key={tab.value}
+                  value={tab.value}
+                  disabled={tab.disabled}
+                  className={[
+                    'group relative',
+                    sizeMap[size],
+                    'rounded-sm transition-colors whitespace-nowrap cursor-pointer select-none outline-none border-0',
+                    activeValue === tab.value ? 'font-medium' : 'hover:bg-gray-100',
+                    'disabled:opacity-50 disabled:cursor-not-allowed',
+                    'focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2'
+                  ].join(' ')}
+                  style={
+                    activeValue === tab.value
+                      ? { backgroundColor: activeColor, color: '#ffffff' }
+                      : { color: activeColor }
+                  }
+                >
+                  {tab.label}
+                  {activeValue === tab.value && (
+                    <svg
+                      className="absolute left-1/2 -translate-x-1/2 -bottom-1.5 w-3 h-1.5"
+                      viewBox="0 0 12 6"
+                      aria-hidden="true"
+                    >
+                      <polygon points="6,6 0,0 12,0" fill={activeColor} />
+                    </svg>
+                  )}
+                </Tabs.Trigger>
+              )
+            }
+
+            return (
+              <Tabs.Trigger
+                key={tab.value}
+                value={tab.value}
+                disabled={tab.disabled}
+                className={[
+                  sizeMap[size],
+                  'flex-1 bg-white text-gray-700 border-0 cursor-default select-none',
+                  'items-center justify-center outline-none transition-colors hover:text-blue-500',
+                  orientation === "HORIZONTAL"
+                    ? 'data-[state=active]:text-blue-500 data-[state=active]:shadow-[inset_0_-2px_0_0] data-[state=active]:shadow-current'
+                    : 'data-[state=active]:text-blue-500 data-[state=active]:shadow-[inset_2px_0_0_0] data-[state=active]:shadow-current',
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
+                  'focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-blue-500'
+                ].filter(Boolean).join(' ')}
+                style={
+                  color.startsWith('#') && value === tab.value
+                    ? { color: color }
+                    : undefined
+                }
+              >
+                {tab.label}
+              </Tabs.Trigger>
+            )
+          })}
         </Tabs.List>
 
         {tabs.map((tab) => (

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,2 +1,2 @@
 export { TabsField } from './TabsField'
-export type { TabsFieldProps, TabItem } from './TabsField'
+export type { TabsFieldProps, TabItem, TabsVariant } from './TabsField'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -69,3 +69,6 @@ export * from './ReadOnlyGrid'
 
 // SiteNav component
 export * from './SiteNav'
+
+// RecordView template
+export * from './RecordView'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -66,3 +66,6 @@ export * from './SideNavAdmin'
 
 // ReadOnlyGrid components
 export * from './ReadOnlyGrid'
+
+// SiteNav component
+export * from './SiteNav'


### PR DESCRIPTION
Adds a page-level RecordView template for prototyping Appian record views.

This PR includes:
- SiteNav: sidebar navigation component with collapsible state, page groups, and user avatar
- TabsField PILL variant: filled background active state with caret indicator, added alongside the existing UNDERLINE variant
- RecordView: full page template composing SiteNav + record header with action buttons (overflow dropdown for 3+) + pill tabs with per-view content support

Each view tab can optionally provide its own content, which is rendered automatically via the pill TabsField. A children slot is also available as a fallback.