### PR TITLE
feat: expand design token generation and add Design Tokens story

### DIFF
--- a/public/tokens.json
+++ b/public/tokens.json
@@ -355,13 +355,66 @@
   },
   "typography": {
     "text-size": {
+      "xs": {
+        "$value": {
+          "value": 0.75,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILSizeExtended.SMALL — text-xs"
+      },
+      "sm": {
+        "$value": {
+          "value": 0.875,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "alias target of text-base — text-sm"
+      },
+      "base": {
+        "$value": "{typography.text-size.sm}",
+        "$type": "dimension",
+        "$description": "SAILSizeExtended.STANDARD — text-base"
+      },
+      "lg": {
+        "$value": {
+          "value": 1.125,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILSizeExtended.MEDIUM — text-lg"
+      },
+      "xl": {
+        "$value": {
+          "value": 1.25,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILSizeExtended.MEDIUM_PLUS — text-xl"
+      },
+      "2xl": {
+        "$value": {
+          "value": 1.5,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILSizeExtended.LARGE — text-2xl"
+      },
       "3xl": {
         "$value": {
           "value": 1.75,
           "unit": "rem"
         },
         "$type": "dimension",
-        "$description": "text-3xl"
+        "$description": "SAILSizeExtended.LARGE_PLUS — text-3xl"
+      },
+      "4xl": {
+        "$value": {
+          "value": 2,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILSizeExtended.EXTRA_LARGE — text-4xl"
       }
     },
     "font-family": {
@@ -419,7 +472,23 @@
           "unit": "rem"
         },
         "$type": "dimension",
-        "$description": "radius-sm"
+        "$description": "SAILShape.SEMI_ROUNDED"
+      },
+      "none": {
+        "$value": {
+          "value": 0,
+          "unit": "px"
+        },
+        "$type": "dimension",
+        "$description": "SAILShape.SQUARED"
+      },
+      "md": {
+        "$value": {
+          "value": 0.5,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILShape.ROUNDED"
       }
     },
     "margin": {
@@ -470,6 +539,56 @@
         },
         "$type": "dimension",
         "$description": "SAILMarginSize.EVEN_MORE"
+      }
+    },
+    "padding": {
+      "none": {
+        "$value": {
+          "value": 0,
+          "unit": "px"
+        },
+        "$type": "dimension",
+        "$description": "SAILPadding.NONE"
+      },
+      "even-less": {
+        "$value": {
+          "value": 0.25,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILPadding.EVEN_LESS"
+      },
+      "less": {
+        "$value": {
+          "value": 0.5,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILPadding.LESS"
+      },
+      "standard": {
+        "$value": {
+          "value": 1,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILPadding.STANDARD"
+      },
+      "more": {
+        "$value": {
+          "value": 1.5,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILPadding.MORE"
+      },
+      "even-more": {
+        "$value": {
+          "value": 2,
+          "unit": "rem"
+        },
+        "$type": "dimension",
+        "$description": "SAILPadding.EVEN_MORE"
       }
     }
   },

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -5,6 +5,7 @@
  * Reads:
  *   - src/index.css   (color palette, typography overrides, spacing/radius)
  *   - src/types/sail.ts (SAIL enum types for semantic tokens)
+ *   - TAILWIND-SAIL-MAPPING.md (spacing scale, padding scale, border radius/shape)
  *
  * Writes:
  *   - dist/tokens.json
@@ -80,6 +81,18 @@ function parseColors(theme: string): { colors: RawColor[]; aliases: Alias[] } {
   return { colors, aliases };
 }
 
+// SAIL size name → text-{key} mapping for $description enrichment
+const TEXT_SIZE_SAIL_MAP: Record<string, string> = {
+  'xs':   'SAILSizeExtended.SMALL',
+  'sm':   'alias target of text-base',
+  'base': 'SAILSizeExtended.STANDARD',
+  'lg':   'SAILSizeExtended.MEDIUM',
+  'xl':   'SAILSizeExtended.MEDIUM_PLUS',
+  '2xl':  'SAILSizeExtended.LARGE',
+  '3xl':  'SAILSizeExtended.LARGE_PLUS',
+  '4xl':  'SAILSizeExtended.EXTRA_LARGE',
+};
+
 function parseTextTokens(theme: string): Array<{ name: string; value: string; dtcgType: string }> {
   const tokens: Array<{ name: string; value: string; dtcgType: string }> = [];
   const re = /--text-([a-zA-Z0-9]+)\s*:\s*([^;]+)/g;
@@ -127,7 +140,65 @@ function parseBaseTypography(css: string): Array<{ name: string; value: string; 
   return tokens;
 }
 
-// ── Gradient Parsing ─────────────────────────────────────────────────
+// ── Markdown Mapping Parser ──────────────────────────────────────────
+
+interface MappingRow {
+  sail: string;          // SAIL enum value, or '-' for non-SAIL rows
+  twClass: string;       // first Tailwind class extracted from backticks
+  value: number;         // numeric value parsed from "Actual Size" column
+  unit: 'px' | 'rem';
+  description: string;  // raw Notes column
+}
+
+/**
+ * Parse a named markdown table from TAILWIND-SAIL-MAPPING.md.
+ * Finds the section by H2 heading, then reads rows until the next H2 or EOF.
+ * Skips rows where SAIL Value is '-' (non-SAIL intermediate values).
+ */
+function parseMappingTable(md: string, sectionHeading: string): MappingRow[] {
+  const headingIdx = md.indexOf(`## ${sectionHeading}`);
+  if (headingIdx === -1) return [];
+
+  // Find the next H2 to know where this section ends
+  const nextH2 = md.indexOf('\n## ', headingIdx + 1);
+  const section = nextH2 === -1 ? md.slice(headingIdx) : md.slice(headingIdx, nextH2);
+
+  const rows: MappingRow[] = [];
+  for (const line of section.split('\n')) {
+    // Table data rows: | SAIL | `class` | size | notes |
+    if (!line.startsWith('|') || line.startsWith('|---') || line.startsWith('| SAIL')) continue;
+
+    const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+    if (cells.length < 3) continue;
+
+    const sail = cells[0];
+    if (sail === '-') continue; // skip non-SAIL intermediate rows
+
+    // Extract first backtick-quoted class
+    const classMatch = cells[1].match(/`([^`]+)`/);
+    if (!classMatch) continue;
+    const twClass = classMatch[1];
+
+    // Parse size: "0" | "4px (0.25rem)" | "8px (0.5rem)"
+    const sizeCell = cells[2];
+    let value: number, unit: 'px' | 'rem';
+    if (sizeCell === '0') {
+      value = 0; unit = 'px';
+    } else {
+      // Prefer rem if present, fall back to px
+      const remMatch = sizeCell.match(/\(([0-9.]+)rem\)/);
+      const pxMatch = sizeCell.match(/^([0-9.]+)px/);
+      if (remMatch) { value = parseFloat(remMatch[1]); unit = 'rem'; }
+      else if (pxMatch) { value = parseFloat(pxMatch[1]); unit = 'px'; }
+      else continue;
+    }
+
+    rows.push({ sail, twClass, value, unit, description: cells[3] ?? '' });
+  }
+  return rows;
+}
+
+
 
 interface RawGradient {
   name: string;
@@ -287,10 +358,12 @@ function main(): void {
   const root = path.resolve(import.meta.dirname, '..');
   const cssPath = path.join(root, 'src/index.css');
   const sailPath = path.join(root, 'src/types/sail.ts');
+  const mappingPath = path.join(root, 'TAILWIND-SAIL-MAPPING.md');
 
   // Read sources
   const cssContent = fs.readFileSync(cssPath, 'utf-8');
   const sailContent = fs.readFileSync(sailPath, 'utf-8');
+  const mappingContent = fs.readFileSync(mappingPath, 'utf-8');
 
   // Parse CSS
   const theme = extractThemeBlock(cssContent);
@@ -305,6 +378,10 @@ function main(): void {
 
   // Parse SAIL types
   const sailEnums = parseSAILTypes(sailContent);
+
+  // Parse mapping doc tables
+  const spacingRows = parseMappingTable(mappingContent, 'Spacing (Padding & Margins)');
+  const shapeRows = parseMappingTable(mappingContent, 'Border Radius (Shape)');
 
   // Build DTCG tree
   const tree: Record<string, DTCGGroup> = { color: {}, typography: {}, spacing: {}, gradient: {} };
@@ -358,17 +435,27 @@ function main(): void {
     }
 
     let $value: unknown;
+    let $type = t.dtcgType;
     if (t.dtcgType === 'fontFamily') {
       $value = parseFontFamily(t.value);
     } else if (t.dtcgType === 'fontWeight') {
       $value = parseInt(t.value, 10) || t.value;
     } else {
-      // dimension
-      $value = parseDimension(t.value);
+      // dimension — handle var() alias refs (e.g. var(--text-sm) → DTCG alias)
+      const varMatch = t.value.match(/^var\(--text-([a-zA-Z0-9]+)\)$/)
+      if (varMatch) {
+        $value = `{typography.text-size.${varMatch[1]}}`
+        $type = 'dimension' // alias inherits type from target
+      } else {
+        $value = parseDimension(t.value);
+      }
     }
 
     setToken(tree.typography, [group, name], {
-      $value, $type: t.dtcgType, $description: t.name,
+      $value, $type,
+      $description: group === 'text-size' && TEXT_SIZE_SAIL_MAP[name]
+        ? `${TEXT_SIZE_SAIL_MAP[name]} — text-${name}`
+        : t.name,
     });
   }
 
@@ -413,6 +500,36 @@ function main(): void {
         }
       }
     }
+  }
+
+  // ── Padding tokens (from TAILWIND-SAIL-MAPPING.md Spacing table) ──
+  // Padding and margin share the same SAIL scale and rem values
+  const SAIL_TO_PADDING_NAME: Record<string, string> = {
+    NONE: 'none', EVEN_LESS: 'even-less', LESS: 'less',
+    STANDARD: 'standard', MORE: 'more', EVEN_MORE: 'even-more',
+  };
+  for (const row of spacingRows) {
+    const paddingName = SAIL_TO_PADDING_NAME[row.sail];
+    if (!paddingName) continue;
+    setToken(tree.spacing, ['padding', paddingName], {
+      $value: row.value === 0 ? { value: 0, unit: 'px' } : { value: row.value, unit: row.unit },
+      $type: 'dimension',
+      $description: `SAILPadding.${row.sail}`,
+    });
+  }
+
+  // ── Shape/radius tokens (from TAILWIND-SAIL-MAPPING.md Border Radius table) ──
+  const SAIL_TO_SHAPE_NAME: Record<string, string> = {
+    SQUARED: 'none', SEMI_ROUNDED: 'sm', ROUNDED: 'md',
+  };
+  for (const row of shapeRows) {
+    const shapeName = SAIL_TO_SHAPE_NAME[row.sail];
+    if (!shapeName) continue;
+    setToken(tree.spacing, ['radius', shapeName], {
+      $value: row.value === 0 ? { value: 0, unit: 'px' } : { value: row.value, unit: row.unit },
+      $type: 'dimension',
+      $description: `SAILShape.${row.sail}`,
+    });
   }
 
   // ── Gradient tokens (parsed from --gradient-* custom properties in CSS) ──

--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -61,6 +61,8 @@ function validateToken(tokenPath: string, token: Record<string, unknown>) {
       break;
 
     case 'dimension': {
+      // Allow DTCG alias refs e.g. "{typography.text-size.sm}"
+      if (typeof val === 'string' && val.startsWith('{')) break;
       if (typeof val !== 'object' || val === null || Array.isArray(val)) {
         err(tokenPath, `dimension $value must be { value, unit }, got ${JSON.stringify(val)}`);
       } else {

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,16 @@
 @import "tailwindcss";
 
 @theme {
-  /* Custom SAIL text size (overrides Tailwind default of 1.875rem/30px) */
-  --text-3xl: 1.75rem;       /* 28px - SAIL LARGE_PLUS */
+  /* SAIL text size scale (SAILSizeExtended) */
+  /* text-base is aliased to text-sm so the default body size is 14px (SAIL STANDARD) */
+  --text-xs:   0.75rem;           /* 12px - SAIL SMALL */
+  --text-sm:   0.875rem;          /* 14px - Tailwind default, explicit for token generation */
+  --text-base: var(--text-sm);    /* 14px - SAIL STANDARD (alias: default body text needs no class) */
+  --text-lg:   1.125rem;          /* 18px - SAIL MEDIUM */
+  --text-xl:   1.25rem;      /* 20px - SAIL MEDIUM_PLUS */
+  --text-2xl:  1.5rem;       /* 24px - SAIL LARGE */
+  --text-3xl:  1.75rem;      /* 28px - SAIL LARGE_PLUS (overrides Tailwind default of 1.875rem) */
+  --text-4xl:  2rem;         /* 32px - SAIL EXTRA_LARGE */
 
   /* Intermediate spacing values (not in Tailwind default scale) */
   --spacing-1\.5: 0.375rem;  /* 6px - for button py-1.5 */
@@ -101,6 +109,7 @@
   html {
     font-family: 'Open Sans', system-ui, -apple-system, sans-serif;
     font-weight: 400;
+    font-size: 1rem;
     font-family-code: 'Geist Mono', 'Fira Code', monospace;
     color: #222222;
     background-color: #FFFFFF;

--- a/src/stories/DesignTokens.stories.tsx
+++ b/src/stories/DesignTokens.stories.tsx
@@ -1,0 +1,323 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import tokens from '../../public/tokens.json'
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function resolveAlias(value: string): string {
+  // e.g. "{color.blue.500}" → tokens.color.blue["500"].$value
+  const match = value.match(/^\{(.+)\}$/)
+  if (!match) return value
+  const parts = match[1].split('.')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let node: any = tokens
+  for (const p of parts) node = node?.[p]
+  return node?.['$value'] ?? value
+}
+
+function isLight(hex: string): boolean {
+  const c = hex.replace('#', '')
+  const r = parseInt(c.slice(0, 2), 16)
+  const g = parseInt(c.slice(2, 4), 16)
+  const b = parseInt(c.slice(4, 6), 16)
+  return (r * 299 + g * 587 + b * 114) / 1000 > 155
+}
+
+// ─── sub-components ─────────────────────────────────────────────────────────
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 style={{ fontFamily: 'Open Sans, system-ui, sans-serif', fontSize: 20, fontWeight: 600, margin: '32px 0 16px', color: '#222' }}>
+      {children}
+    </h2>
+  )
+}
+
+function SubTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 style={{ fontFamily: 'Open Sans, system-ui, sans-serif', fontSize: 13, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#6C6C75', margin: '24px 0 10px' }}>
+      {children}
+    </h3>
+  )
+}
+
+// ─── Color palette ───────────────────────────────────────────────────────────
+
+const COLOR_FAMILIES = ['red', 'orange', 'yellow', 'green', 'teal', 'sky', 'blue', 'purple', 'pink', 'gray'] as const
+const STEPS = ['50', '100', '200', '500', '700', '900'] as const
+
+function ColorPalette() {
+  return (
+    <div>
+      <SectionTitle>Color Palette</SectionTitle>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 24 }}>
+        {COLOR_FAMILIES.map(family => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const familyTokens = (tokens.color as any)[family]
+          return (
+            <div key={family}>
+              <SubTitle>{family}</SubTitle>
+              <div style={{ display: 'flex', borderRadius: 8, overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}>
+                {STEPS.map(step => {
+                  const hex: string = familyTokens[step]?.['$value'] ?? '#ccc'
+                  const light = isLight(hex)
+                  return (
+                    <div
+                      key={step}
+                      title={`${family}-${step}: ${hex}`}
+                      style={{
+                        flex: 1,
+                        background: hex,
+                        padding: '12px 4px',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        gap: 4,
+                      }}
+                    >
+                      <span style={{ fontSize: 10, fontWeight: 700, color: light ? '#222' : '#fff', fontFamily: 'monospace' }}>{step}</span>
+                      <span style={{ fontSize: 9, color: light ? '#444' : 'rgba(255,255,255,0.8)', fontFamily: 'monospace', wordBreak: 'break-all', textAlign: 'center' }}>{hex}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── Semantic colors ─────────────────────────────────────────────────────────
+
+const SEMANTIC_LABELS: Record<string, string> = {
+  accent: 'ACCENT',
+  positive: 'POSITIVE',
+  destructive: 'NEGATIVE',
+  secondary: 'SECONDARY',
+  standard: 'STANDARD',
+}
+
+function SemanticColors() {
+  return (
+    <div>
+      <SectionTitle>Semantic Colors</SectionTitle>
+      <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+        {Object.entries(tokens.color.semantic).map(([key, token]) => {
+          const hex = resolveAlias(token['$value'] as string)
+          const light = isLight(hex)
+          return (
+            <div key={key} style={{ width: 140 }}>
+              <div style={{
+                background: hex,
+                borderRadius: 8,
+                height: 72,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.12)',
+              }}>
+                <span style={{ fontFamily: 'monospace', fontSize: 11, fontWeight: 700, color: light ? '#222' : '#fff' }}>{hex}</span>
+              </div>
+              <div style={{ marginTop: 6, fontFamily: 'Open Sans, sans-serif', fontSize: 13, fontWeight: 600, color: '#222' }}>{SEMANTIC_LABELS[key] ?? key}</div>
+              <div style={{ fontFamily: 'monospace', fontSize: 10, color: '#6C6C75', wordBreak: 'break-word' }}>{token['$description']}</div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── Gradients ───────────────────────────────────────────────────────────────
+
+function Gradients() {
+  const { 'header-bg': headerBg, 'header-overlay': headerOverlay } = tokens.gradient
+
+  const bgStops = (headerBg['$value'] as Array<{ color: string; position: number }>)
+    .map(s => `${s.color} ${Math.round(s.position * 100)}%`)
+    .join(', ')
+
+  const overlayStops = (headerOverlay['$value'] as Array<{ color: string; position: number }>)
+    .map(s => `${s.color} ${Math.round(s.position * 100)}%`)
+    .join(', ')
+
+  return (
+    <div>
+      <SectionTitle>Gradients</SectionTitle>
+      <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+        <div style={{ flex: 1, minWidth: 280 }}>
+          <SubTitle>header-bg</SubTitle>
+          <div style={{ height: 80, borderRadius: 8, background: `linear-gradient(to right, ${bgStops})`, boxShadow: '0 1px 3px rgba(0,0,0,0.12)' }} />
+          <div style={{ marginTop: 6, fontFamily: 'monospace', fontSize: 11, color: '#6C6C75' }}>{headerBg['$description']}</div>
+        </div>
+        <div style={{ flex: 1, minWidth: 280 }}>
+          <SubTitle>header-overlay</SubTitle>
+          <div style={{ height: 80, borderRadius: 8, background: `linear-gradient(to right, ${overlayStops})`, border: '1px solid #E0E0E0', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }} />
+          <div style={{ marginTop: 6, fontFamily: 'monospace', fontSize: 11, color: '#6C6C75' }}>{headerOverlay['$description']}</div>
+        </div>
+      </div>
+      <div style={{ marginTop: 16 }}>
+        <SubTitle>Combined (bg + overlay)</SubTitle>
+        <div style={{ height: 80, borderRadius: 8, position: 'relative', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.12)' }}>
+          <div style={{ position: 'absolute', inset: 0, background: `linear-gradient(to right, ${bgStops})` }} />
+          <div style={{ position: 'absolute', inset: 0, background: `linear-gradient(to right, ${overlayStops})` }} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Typography ──────────────────────────────────────────────────────────────
+
+function Typography() {
+  const { 'font-family': fontFamily, 'font-weight': fontWeight, 'text-size': textSize } = tokens.typography
+
+  return (
+    <div>
+      <SectionTitle>Typography</SectionTitle>
+
+      <SubTitle>Font Families</SubTitle>
+      <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+        {Object.entries(fontFamily).map(([key, token]) => {
+          const families = (token['$value'] as string[]).join(', ')
+          return (
+            <div key={key} style={{ background: '#F5F5F7', borderRadius: 8, padding: '16px 20px', minWidth: 220 }}>
+              <div style={{ fontFamily: families, fontSize: 22, marginBottom: 8, color: '#222' }}>Aa Bb Cc 123</div>
+              <div style={{ fontFamily: 'monospace', fontSize: 11, fontWeight: 700, color: '#6C6C75', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{key}</div>
+              <div style={{ fontFamily: 'monospace', fontSize: 11, color: '#6C6C75', marginTop: 2 }}>{families}</div>
+            </div>
+          )
+        })}
+      </div>
+
+      <SubTitle>Font Weight</SubTitle>
+      <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+        {Object.entries(fontWeight).map(([key, token]) => (
+          <div key={key} style={{ background: '#F5F5F7', borderRadius: 8, padding: '12px 16px' }}>
+            <div style={{ fontWeight: token['$value'] as number, fontSize: 18, color: '#222', fontFamily: 'Open Sans, sans-serif' }}>The quick brown fox</div>
+            <div style={{ fontFamily: 'monospace', fontSize: 11, color: '#6C6C75', marginTop: 4 }}>{key} — {String(token['$value'])}</div>
+          </div>
+        ))}
+      </div>
+
+      <SubTitle>Text Size</SubTitle>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {Object.entries(textSize).map(([key, token]) => {
+          const raw = token['$value']
+          const isAlias = typeof raw === 'string' && raw.startsWith('{')
+          const resolvedValue = isAlias
+            ? resolveAlias(raw) as unknown as { value: number; unit: string }
+            : raw as { value: number; unit: string }
+          const desc = token['$description'] as string
+          const sailName = desc.split('—')[0].trim()
+          // rem values are relative to browser default 16px root
+          const px = Math.round(resolvedValue.value * 16)
+          const sizeLabel = isAlias
+            ? `→ text-${raw.replace(/^\{typography\.text-size\./, '').replace(/\}$/, '')} (${resolvedValue.value}rem / ${px}px)`
+            : `${resolvedValue.value}${resolvedValue.unit} / ${px}px`
+          return (
+            <div key={key} style={{ display: 'flex', alignItems: 'baseline', gap: 16 }}>
+              <span style={{ width: 80, fontFamily: 'monospace', fontSize: 11, color: '#6C6C75', flexShrink: 0 }}>text-{key}</span>
+              <span style={{ fontSize: `${resolvedValue.value}${resolvedValue.unit}`, fontFamily: 'Open Sans, sans-serif', color: '#222', lineHeight: 1.2 }}>The quick brown fox</span>
+              <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#6C6C75' }}>{sizeLabel}</span>
+              <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#2322F0' }}>{sailName}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── Spacing ─────────────────────────────────────────────────────────────────
+
+function Spacing() {
+  const { margin, spacing: spacingScale, radius } = tokens.spacing
+
+  return (
+    <div>
+      <SectionTitle>Spacing</SectionTitle>
+
+      <SubTitle>Margin Scale (SAIL)</SubTitle>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {Object.entries(margin).map(([key, token]) => {
+          const val = token['$value'] as { value: number; unit: string }
+          const px = val.unit === 'rem' ? val.value * 16 : val.value
+          const width = Math.max(px, 4)
+          return (
+            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <div style={{ width: 100, fontFamily: 'monospace', fontSize: 12, color: '#222', textAlign: 'right' }}>{key}</div>
+              <div style={{ width, height: 20, background: '#2322F0', borderRadius: 3, minWidth: 4 }} />
+              <div style={{ fontFamily: 'monospace', fontSize: 11, color: '#6C6C75' }}>{val.value}{val.unit} ({px}px) — {token['$description']}</div>
+            </div>
+          )
+        })}
+      </div>
+
+      <SubTitle>Spacing Tokens</SubTitle>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        {Object.entries(spacingScale).map(([key, token]) => {
+          const val = token['$value'] as { value: number; unit: string }
+          const px = val.value * 16
+          return (
+            <div key={key} style={{ background: '#F5F5F7', borderRadius: 6, padding: '10px 14px', textAlign: 'center' }}>
+              <div style={{ width: px, height: px, background: '#2322F0', borderRadius: 3, margin: '0 auto 6px' }} />
+              <div style={{ fontFamily: 'monospace', fontSize: 11, color: '#222' }}>{key}</div>
+              <div style={{ fontFamily: 'monospace', fontSize: 10, color: '#6C6C75' }}>{val.value}{val.unit}</div>
+            </div>
+          )
+        })}
+      </div>
+
+      <SubTitle>Border Radius</SubTitle>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        {Object.entries(radius).map(([key, token]) => {
+          const val = token['$value'] as { value: number; unit: string }
+          const px = val.value * 16
+          return (
+            <div key={key} style={{ background: '#F5F5F7', borderRadius: 6, padding: '10px 14px', textAlign: 'center' }}>
+              <div style={{ width: 48, height: 48, background: '#2322F0', borderRadius: px, margin: '0 auto 6px' }} />
+              <div style={{ fontFamily: 'monospace', fontSize: 11, color: '#222' }}>{key}</div>
+              <div style={{ fontFamily: 'monospace', fontSize: 10, color: '#6C6C75' }}>{val.value}{val.unit} ({px}px)</div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── Full page ────────────────────────────────────────────────────────────────
+
+function DesignTokensPage() {
+  return (
+    <div style={{ padding: '32px 40px', maxWidth: 1100, fontFamily: 'Open Sans, system-ui, sans-serif' }}>
+      <h1 style={{ fontSize: 28, fontWeight: 700, color: '#222', margin: '0 0 4px' }}>Design Tokens</h1>
+      <p style={{ color: '#6C6C75', fontSize: 14, margin: '0 0 8px' }}>
+        Aurora color palette, semantic mappings, typography, spacing, and gradients — sourced from{' '}
+        <code style={{ fontFamily: 'monospace', background: '#EDEDF2', padding: '1px 5px', borderRadius: 4 }}>public/tokens.json</code>
+      </p>
+      <hr style={{ border: 'none', borderTop: '1px solid #E0E0E0', margin: '20px 0 0' }} />
+      <ColorPalette />
+      <SemanticColors />
+      <Gradients />
+      <Typography />
+      <Spacing />
+    </div>
+  )
+}
+
+// ─── Story ────────────────────────────────────────────────────────────────────
+
+const meta = {
+  title: 'Foundation/Design Tokens',
+  component: DesignTokensPage,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DesignTokensPage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllTokens: Story = {}


### PR DESCRIPTION
## What changed

### New: Design Tokens Storybook page
Added `src/stories/DesignTokens.stories.tsx` — a `Foundation/Design Tokens` page in Storybook that renders all tokens directly from `public/tokens.json`. Sections:
- **Color palette** — all 10 Aurora families with hex swatches at each step (50→900)
- **Semantic colors** — ACCENT, POSITIVE, NEGATIVE, SECONDARY, STANDARD with resolved hex values
- **Gradients** — header-bg, header-overlay, and composited preview
- **Typography** — font families, font weight, and the full text size scale with rem + px values
- **Spacing** — margin scale, spacing tokens, and border radius visual reference

### Token generator now covers the full SAIL size scale
Previously only `--text-3xl` was defined in `@theme` (it was the only override from Tailwind defaults). The generator only captured that one token.

Now all 7 `SAILSizeExtended` sizes are explicit in `@theme`:
```
--text-xs   → SAIL SMALL       (0.75rem / 12px)
--text-sm   → alias target     (0.875rem / 14px)
--text-base → SAIL STANDARD    (alias of text-sm)
--text-lg   → SAIL MEDIUM      (1.125rem / 18px)
--text-xl   → SAIL MEDIUM_PLUS (1.25rem / 20px)
--text-2xl  → SAIL LARGE       (1.5rem / 24px)
--text-3xl  → SAIL LARGE_PLUS  (1.75rem / 28px) ← still the only real override
--text-4xl  → SAIL EXTRA_LARGE (2rem / 32px)
```

### text-base aliased to text-sm (14px default body text)
`--text-base: var(--text-sm)` in `@theme` means Tailwind compiles `text-base` utilities to 14px — matching SAIL's 14px standard body size — without needing explicit classes on every element. Verified working in Tailwind v4.

The generator detects `var()` references and emits proper DTCG alias tokens:
```json
"base": { "$value": "{typography.text-size.sm}", "$type": "dimension" }
```

The validator was updated to accept DTCG alias refs on dimension tokens.

### Padding and shape tokens now generated from TAILWIND-SAIL-MAPPING.md
Previously the generator had no padding tokens at all, and radius only had `sm` (the CSS override). Shape tokens (`SQUARED`, `ROUNDED`) were missing entirely.

The generator now parses the **Spacing** and **Border Radius** tables from `TAILWIND-SAIL-MAPPING.md` to emit:
- `spacing.padding` — full `SAILPadding` scale (NONE → EVEN_MORE)
- `spacing.radius` — all three `SAILShape` values (none, sm, md)

This means `TAILWIND-SAIL-MAPPING.md` is now load-bearing for these tokens — it's the single source of truth for these 1:1 SAIL→Tailwind mappings, avoiding duplication in both CSS and the generator script.

### Token count
| Category | Before | After |
|----------|--------|-------|
| Color | 66 | 66 |
| Typography | 1 | 11 |
| Spacing | 9 | 17 |

## What's not changed (intentionally)
- Semantic color mappings still live in `SEMANTIC_COLOR_MAP` in the generator — these are context-sensitive and not suitable for a flat markdown table
- Margin tokens still come from `SAILMarginSize` in `sail.ts` — no change there
- The spacing intermediate values (1.5, 2.5) still come from `@theme` CSS

## Known open questions (not blocking)
- Whether to drop the `@theme` text size declarations and drive everything from the mapping doc (Tailwind v4 doesn't expose a JS API to read resolved theme values, so some duplication is unavoidable for now)
- Full pixel-matching with real SAIL — currently a prototyping tool, scope may be evolving