### PR TITLE
fix: use empty string for NONE margin values

### DIFF
--- a/src/components/Button/ButtonArrayLayout.tsx
+++ b/src/components/Button/ButtonArrayLayout.tsx
@@ -50,7 +50,7 @@ export const ButtonArrayLayout: React.FC<ButtonArrayLayoutProps> = ({
 
   // Margin mappings - using Tailwind standard classes that map to SAIL values
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',      // SAIL NONE: 0
+    NONE: '',           // SAIL NONE: no class needed
     EVEN_LESS: 'mb-1', // SAIL EVEN_LESS: 4px
     LESS: 'mb-2',      // SAIL LESS: 8px
     STANDARD: 'mb-4',  // SAIL STANDARD: 16px

--- a/src/components/Card/CardLayout.tsx
+++ b/src/components/Card/CardLayout.tsx
@@ -92,7 +92,7 @@ export const CardLayout: React.FC<CardLayoutProps> = ({
 
   // Margin mappings - using Tailwind standard classes that map to SAIL values
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',      // SAIL NONE: 0
+    NONE: '',           // SAIL NONE: no class needed
     EVEN_LESS: 'mt-1', // SAIL EVEN_LESS: 4px
     LESS: 'mt-2',      // SAIL LESS: 8px
     STANDARD: 'mt-4',  // SAIL STANDARD: 16px
@@ -101,7 +101,7 @@ export const CardLayout: React.FC<CardLayoutProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',      // SAIL NONE: 0
+    NONE: '',           // SAIL NONE: no class needed
     EVEN_LESS: 'mb-1', // SAIL EVEN_LESS: 4px
     LESS: 'mb-2',      // SAIL LESS: 8px
     STANDARD: 'mb-4',  // SAIL STANDARD: 16px

--- a/src/components/Heading/HeadingField.tsx
+++ b/src/components/Heading/HeadingField.tsx
@@ -91,7 +91,7 @@ export const HeadingField: React.FC<HeadingFieldProps> = ({
 
   // Margin mappings
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',
+    NONE: '',
     EVEN_LESS: 'mt-1',
     LESS: 'mt-2',
     STANDARD: 'mt-4',
@@ -100,7 +100,7 @@ export const HeadingField: React.FC<HeadingFieldProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',
+    NONE: '',
     EVEN_LESS: 'mb-1',
     LESS: 'mb-2',
     STANDARD: 'mb-4',

--- a/src/components/MessageBanner/MessageBanner.tsx
+++ b/src/components/MessageBanner/MessageBanner.tsx
@@ -69,7 +69,7 @@ export const MessageBanner: React.FC<MessageBannerProps> = ({
 
   // Styling maps using standard Tailwind classes
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',
+    NONE: '',
     EVEN_LESS: 'mt-1',
     LESS: 'mt-2',
     STANDARD: 'mt-4',
@@ -78,7 +78,7 @@ export const MessageBanner: React.FC<MessageBannerProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',
+    NONE: '',
     EVEN_LESS: 'mb-1',
     LESS: 'mb-2',
     STANDARD: 'mb-4',

--- a/src/components/Milestone/MilestoneField.tsx
+++ b/src/components/Milestone/MilestoneField.tsx
@@ -64,7 +64,7 @@ export const MilestoneField: React.FC<MilestoneFieldProps> = ({
 
   // Map SAIL margin values to Tailwind classes
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',
+    NONE: '',
     EVEN_LESS: 'mt-1',
     LESS: 'mt-2',
     STANDARD: 'mt-4',
@@ -73,7 +73,7 @@ export const MilestoneField: React.FC<MilestoneFieldProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',
+    NONE: '',
     EVEN_LESS: 'mb-1',
     LESS: 'mb-2',
     STANDARD: 'mb-4',

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -59,7 +59,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
 
   // Styling maps using standard Tailwind classes
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',
+    NONE: '',
     EVEN_LESS: 'mt-1',
     LESS: 'mt-2',
     STANDARD: 'mt-4',
@@ -68,7 +68,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',
+    NONE: '',
     EVEN_LESS: 'mb-1',
     LESS: 'mb-2',
     STANDARD: 'mb-4',

--- a/src/components/RichText/RichTextDisplayField.tsx
+++ b/src/components/RichText/RichTextDisplayField.tsx
@@ -53,7 +53,7 @@ export const RichTextDisplayField: React.FC<RichTextDisplayFieldProps> = ({
 
   // Margin mappings
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',
+    NONE: '',
     EVEN_LESS: 'mt-1',
     LESS: 'mt-2',
     STANDARD: 'mt-4',
@@ -62,7 +62,7 @@ export const RichTextDisplayField: React.FC<RichTextDisplayFieldProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',
+    NONE: '',
     EVEN_LESS: 'mb-1',
     LESS: 'mb-2',
     STANDARD: 'mb-4',

--- a/src/components/Stamp/StampField.tsx
+++ b/src/components/Stamp/StampField.tsx
@@ -71,7 +71,7 @@ export const StampField: React.FC<StampFieldProps> = ({
 
   // Styling maps using standard Tailwind classes
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',
+    NONE: '',
     EVEN_LESS: 'mt-1',
     LESS: 'mt-2',
     STANDARD: 'mt-4',
@@ -80,7 +80,7 @@ export const StampField: React.FC<StampFieldProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',
+    NONE: '',
     EVEN_LESS: 'mb-1',
     LESS: 'mb-2',
     STANDARD: 'mb-4',

--- a/src/components/Tag/TagField.tsx
+++ b/src/components/Tag/TagField.tsx
@@ -79,7 +79,7 @@ export const TagField: React.FC<TagFieldProps> = ({
 
   // Margin mappings - using Tailwind standard classes that map to SAIL values
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',      // SAIL NONE: 0
+    NONE: '',           // SAIL NONE: no class needed
     EVEN_LESS: 'mt-1', // SAIL EVEN_LESS: 4px
     LESS: 'mt-2',      // SAIL LESS: 8px
     STANDARD: 'mt-4',  // SAIL STANDARD: 16px
@@ -88,7 +88,7 @@ export const TagField: React.FC<TagFieldProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',      // SAIL NONE: 0
+    NONE: '',           // SAIL NONE: no class needed
     EVEN_LESS: 'mb-1', // SAIL EVEN_LESS: 4px
     LESS: 'mb-2',      // SAIL LESS: 8px
     STANDARD: 'mb-4',  // SAIL STANDARD: 16px

--- a/src/components/shared/FieldWrapper.tsx
+++ b/src/components/shared/FieldWrapper.tsx
@@ -49,7 +49,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
 }) => {
   // Map SAIL margin values to Tailwind classes
   const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: 'mt-0',
+    NONE: '',
     EVEN_LESS: 'mt-1',
     LESS: 'mt-2',
     STANDARD: 'mt-4',
@@ -58,7 +58,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
   }
 
   const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: 'mb-0',
+    NONE: '',
     EVEN_LESS: 'mb-1',
     LESS: 'mb-2',
     STANDARD: 'mb-4',


### PR DESCRIPTION
Fixes #23

Changed all margin maps to use empty string `''` instead of `mt-0`/`mb-0` for `NONE` values. The issue listed 3 affected components, but I found 7 more using the same pattern:

- ButtonArrayLayout
- CardLayout
- TagField
- HeadingField
- RichTextDisplayField
- StampField
- MessageBanner
- ProgressBar
- MilestoneField
- FieldWrapper (shared)

Left `NONE: 'p-0'` in CardLayout's padding map untouched — that's an intentional padding reset, not a no-op margin.

---

Side note: while making this change I noticed all 10 components define identical margin maps independently. Issue #19 proposed extracting these into a shared utility (`src/utils/margins.ts`), and it was closed via PR #1 which shared the types but not the maps themselves. Would it be worth reopening that idea, or is the per-component duplication acceptable for now? Happy to take that on as a follow-up if you think it's worthwhile.
