### PR TITLE
fix: emit .d.ts files at correct paths in library build

### DIFF
--- a/src/components/Switch/SwitchField.tsx
+++ b/src/components/Switch/SwitchField.tsx
@@ -62,7 +62,7 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
   onChange,
   validationGroup: _validationGroup,
   requiredMessage,
-  labelPosition = "ABOVE",
+  labelPosition: _labelPosition = "ABOVE",
   helpTooltip,
   accessibilityText,
   showWhen = true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => {
         react(),
         dts({
           tsconfigPath: './tsconfig.lib.json',
+          entryRoot: 'src',
         }),
       ],
       build: {


### PR DESCRIPTION
## Summary

Fixes #65 — published package was missing usable type declarations.

## Root Cause

`vite-plugin-dts` was emitting declaration files to `dist/src/index.d.ts` while Rollup (via `preserveModulesRoot: 'src'`) was emitting JS to `dist/index.js`. The path mismatch meant `package.json`'s `"types": "./dist/index.d.ts"` pointed to a file that didn't exist.

## Fix

Added `entryRoot: 'src'` to the `vite-plugin-dts` config so it strips the `src/` prefix from output paths, matching Rollup's behavior.

Also prefixed the unused `labelPosition` destructure in `SwitchField` with underscore to suppress the TS6133 error during declaration generation.