### PR TITLE
fix: add saveInto with state to all interactive component stories

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -51,6 +51,10 @@ export const CompactLayout: Story = {
     value: [],
     choiceLayout: 'COMPACT',
   },
+  render: (args) => {
+    const [value, setValue] = useState<string[]>(args.value ?? [])
+    return <CheckboxField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const CardsStyle: Story = {
@@ -82,6 +86,10 @@ export const AdjacentLabel: Story = {
     choiceValues: ['agreed'],
     value: [],
   },
+  render: (args) => {
+    const [value, setValue] = useState<string[]>(args.value ?? [])
+    return <CheckboxField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const WithRequiredAndValidation: Story = {
@@ -94,6 +102,10 @@ export const WithRequiredAndValidation: Story = {
     required: true,
     requiredMessage: 'This field is required',
     validations: [],
+  },
+  render: (args) => {
+    const [value, setValue] = useState<string[]>(args.value ?? [])
+    return <CheckboxField {...args} value={value} saveInto={setValue} />
   },
 }
 
@@ -114,6 +126,10 @@ export const SpacingVariations: Story = {
     choiceValues: ['1', '2', '3'],
     value: [],
     spacing: 'STANDARD',
+  },
+  render: (args) => {
+    const [value, setValue] = useState<string[]>(args.value ?? [])
+    return <CheckboxField {...args} value={value} saveInto={setValue} />
   },
 }
 

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -132,6 +132,16 @@ export const AdjacentLabel: Story = {
     choiceValues: ['low', 'med', 'high', 'crit'],
     value: 'med',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <DropdownField
+        {...args}
+        value={value}
+        saveInto={setValue}
+      />
+    )
+  },
 }
 
 export const MultipleDefault: Story = {

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -113,6 +113,10 @@ export const AdjacentLabel: Story = {
     choiceValues: ['active', 'inactive'],
     value: 'active',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <RadioButtonField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const WithRequiredAndInstructions: Story = {

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -133,11 +133,14 @@ export const SizeSmall: Story = {
     color: 'ACCENT',
     size: 'SMALL',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const SizeStandard: Story = {
@@ -149,11 +152,14 @@ export const SizeStandard: Story = {
     color: 'ACCENT',
     size: 'STANDARD',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const SizeMedium: Story = {
@@ -165,11 +171,14 @@ export const SizeMedium: Story = {
     color: 'ACCENT',
     size: 'MEDIUM',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const SizeLarge: Story = {
@@ -181,11 +190,14 @@ export const SizeLarge: Story = {
     color: 'ACCENT',
     size: 'LARGE',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const ColorAccent: Story = {
@@ -196,11 +208,14 @@ export const ColorAccent: Story = {
     max: 100,
     color: 'ACCENT',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const ColorPositive: Story = {
@@ -211,11 +226,14 @@ export const ColorPositive: Story = {
     max: 100,
     color: 'POSITIVE',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const ColorNegative: Story = {
@@ -226,11 +244,14 @@ export const ColorNegative: Story = {
     max: 100,
     color: 'NEGATIVE',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const ColorCustomHex: Story = {
@@ -241,11 +262,14 @@ export const ColorCustomHex: Story = {
     max: 100,
     color: '#9333EA',
   },
-  render: (args) => (
-    <div style={{ width: 320 }}>
-      <SliderField {...args} saveInto={() => {}} />
-    </div>
-  ),
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div style={{ width: 320 }}>
+        <SliderField {...args} value={value} saveInto={(v) => setValue(v as number)} />
+      </div>
+    )
+  },
 }
 
 export const Disabled: Story = {

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -65,6 +65,10 @@ export const SmallSize: Story = {
     value: true,
     size: 'SMALL',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const StandardSize: Story = {
@@ -72,6 +76,10 @@ export const StandardSize: Story = {
     label: 'Standard Switch',
     value: true,
     size: 'STANDARD',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
   },
 }
 
@@ -81,6 +89,10 @@ export const MediumSize: Story = {
     value: true,
     size: 'MEDIUM',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const LargeSize: Story = {
@@ -89,17 +101,23 @@ export const LargeSize: Story = {
     value: true,
     size: 'LARGE',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const AllSizes: Story = {
   args: { label: '', value: true },
   render: () => {
     const sizes = ['SMALL', 'STANDARD', 'MEDIUM', 'LARGE'] as const
+    const SizeRow = ({ s }: { s: typeof sizes[number] }) => {
+      const [value, setValue] = useState(true)
+      return <SwitchField label={`${s} size`} value={value} saveInto={setValue} size={s} marginBelow="NONE" />
+    }
     return (
       <div className="flex flex-col gap-4">
-        {sizes.map((s) => (
-          <SwitchField key={s} label={`${s} size`} value={true} size={s} marginBelow="NONE" />
-        ))}
+        {sizes.map((s) => <SizeRow key={s} s={s} />)}
       </div>
     )
   },
@@ -113,6 +131,10 @@ export const ColorAccent: Story = {
     value: true,
     color: 'ACCENT',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const ColorPositive: Story = {
@@ -120,6 +142,10 @@ export const ColorPositive: Story = {
     label: 'POSITIVE (Green)',
     value: true,
     color: 'POSITIVE',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
   },
 }
 
@@ -129,6 +155,10 @@ export const ColorNegative: Story = {
     value: true,
     color: 'NEGATIVE',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const CustomHexColor: Story = {
@@ -136,6 +166,10 @@ export const CustomHexColor: Story = {
     label: 'Custom Hex Color',
     value: true,
     color: '#9333EA',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
   },
 }
 
@@ -165,6 +199,10 @@ export const LabelOnRight: Story = {
     value: true,
     switchLabelPosition: 'RIGHT',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const LabelOnLeft: Story = {
@@ -173,14 +211,28 @@ export const LabelOnLeft: Story = {
     value: true,
     switchLabelPosition: 'LEFT',
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return <SwitchField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const LabelPositionComparison: Story = {
   args: { label: '', value: true },
-  render: () => (
-    <div className="flex flex-col gap-4">
-      <SwitchField label="Label on Right" value={true} switchLabelPosition="RIGHT" marginBelow="NONE" />
-      <SwitchField label="Label on Left" value={true} switchLabelPosition="LEFT" marginBelow="NONE" />
-    </div>
-  ),
+  render: () => {
+    const RightLabel = () => {
+      const [value, setValue] = useState(true)
+      return <SwitchField label="Label on Right" value={value} saveInto={setValue} switchLabelPosition="RIGHT" marginBelow="NONE" />
+    }
+    const LeftLabel = () => {
+      const [value, setValue] = useState(true)
+      return <SwitchField label="Label on Left" value={value} saveInto={setValue} switchLabelPosition="LEFT" marginBelow="NONE" />
+    }
+    return (
+      <div className="flex flex-col gap-4">
+        <RightLabel />
+        <LeftLabel />
+      </div>
+    )
+  },
 }

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -52,6 +52,10 @@ export const WithCharacterLimit: Story = {
     characterLimit: 12,
     showCharacterCount: true,
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '')
+    return <TextField {...args} value={value} saveInto={setValue} />
+  },
 }
 
 export const Masked: Story = {
@@ -60,6 +64,10 @@ export const Masked: Story = {
     masked: true,
     placeholder: 'Enter password',
     required: true,
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '')
+    return <TextField {...args} value={value} saveInto={setValue} />
   },
 }
 
@@ -76,6 +84,10 @@ export const AdjacentLabel: Story = {
     label: 'First Name',
     labelPosition: 'ADJACENT',
     value: 'John',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '')
+    return <TextField {...args} value={value} saveInto={setValue} />
   },
 }
 
@@ -95,6 +107,10 @@ export const WithHelpTooltip: Story = {
     helpTooltip:
       'Your username must be 3-20 characters long and contain only letters, numbers, and underscores',
     placeholder: 'username',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '')
+    return <TextField {...args} value={value} saveInto={setValue} />
   },
 }
 


### PR DESCRIPTION
Ensures all non-disabled/non-readonly interactive stories respond to user interaction by wiring up `useState` + `saveInto`.

**Components fixed:**
- **Checkbox** — CompactLayout, AdjacentLabel, WithRequiredAndValidation, SpacingVariations
- **TextField** — WithCharacterLimit, Masked, AdjacentLabel, WithHelpTooltip
- **RadioButton** — AdjacentLabel
- **Switch** — all size, color, and label position stories (12 total)
- **Slider** — replaced no-op `saveInto` with real state on 8 size/color stories
- **Dropdown** — AdjacentLabel

Disabled and ReadOnly stories were intentionally left as-is since they're not meant to be interactive.

Closes #56