### PR TITLE
Switch to studio palette fork

### DIFF
--- a/src/components/Switch/SwitchField.tsx
+++ b/src/components/Switch/SwitchField.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as Switch from '@radix-ui/react-switch'
+import { Info } from 'lucide-react'
 import { FieldWrapper } from '../shared/FieldWrapper'
 import type { SAILLabelPosition, SAILMarginSize, SAILSize } from '../../types/sail'
 
@@ -46,7 +47,7 @@ export interface SwitchFieldProps {
   /** Size of the switch and its label */
   size?: SAILSize
   /** Color when switch is on (hex or semantic) */
-  color?: "ACCENT" | "POSITIVE" | "NEGATIVE" | string
+  color?: "ACCENT" | "POSITIVE" | "NEGATIVE" | "SECONDARY" | "STANDARD" | string
   /** Position of the inline label relative to the switch control: LEFT or RIGHT */
   switchLabelPosition?: "LEFT" | "RIGHT"
   /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
@@ -84,19 +85,19 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
   const sizeMap: Record<SAILSize, { root: string; thumb: string }> = {
     SMALL: {
       root: 'h-5 w-9',
-      thumb: 'h-4 w-4 data-[state=checked]:translate-x-4'
+      thumb: 'h-3.5 w-3.5 data-[state=checked]:translate-x-4'
     },
     STANDARD: {
       root: 'h-6 w-11',
-      thumb: 'h-5 w-5 data-[state=checked]:translate-x-5'
+      thumb: 'h-4 w-4 data-[state=checked]:translate-x-5'
     },
     MEDIUM: {
       root: 'h-7 w-14',
-      thumb: 'h-6 w-6 data-[state=checked]:translate-x-7'
+      thumb: 'h-5 w-5 data-[state=checked]:translate-x-7'
     },
     LARGE: {
       root: 'h-9 w-18',
-      thumb: 'h-8 w-8 data-[state=checked]:translate-x-9'
+      thumb: 'h-7 w-7 data-[state=checked]:translate-x-9'
     }
   }
 
@@ -118,14 +119,14 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
 
   // Color mapping for checked state
   const getCheckedBgClass = (): string => {
-    if (color.startsWith('#')) {
-      return '' // Use inline style instead
-    }
+    if (color.startsWith('#')) return ''
 
     const colorMap: Record<string, string> = {
-      ACCENT: 'data-[state=checked]:bg-blue-500',
-      POSITIVE: 'data-[state=checked]:bg-green-700',
-      NEGATIVE: 'data-[state=checked]:bg-red-700'
+      ACCENT:    'data-[state=checked]:bg-blue-500',
+      POSITIVE:  'data-[state=checked]:bg-green-700',
+      NEGATIVE:  'data-[state=checked]:bg-red-700',
+      SECONDARY: 'data-[state=checked]:bg-gray-700',
+      STANDARD:  'data-[state=checked]:bg-gray-900'
     }
 
     return colorMap[color] || 'data-[state=checked]:bg-blue-500'
@@ -155,7 +156,8 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
       className={[
         sizeMap[size].root,
         'shrink-0 relative rounded-full transition-colors border-2',
-        'data-[state=unchecked]:bg-gray-500 data-[state=unchecked]:border-gray-700',
+        'data-[state=unchecked]:bg-white data-[state=unchecked]:border-gray-300',
+        'hover:data-[state=unchecked]:bg-gray-100',
         getCheckedBgClass(),
         'data-[state=checked]:border-transparent',
         'disabled:opacity-50 disabled:cursor-not-allowed',
@@ -170,10 +172,23 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
       <Switch.Thumb
         className={[
           sizeMap[size].thumb,
-          'block rounded-full bg-white shadow-lg transition-transform',
-          'translate-x-0.5'
+          'block rounded-full bg-white shadow-lg transition-transform border border-gray-500 data-[state=checked]:border-transparent',
+          'translate-x-0.5',
+          'flex items-center justify-center'
         ].filter(Boolean).join(' ')}
-      />
+      >
+        {value && (
+          <svg viewBox="0 0 12 12" fill="none" className="w-2/3 h-2/3" aria-hidden="true">
+            <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              className={color.startsWith('#') ? '' : {
+                ACCENT: 'text-blue-500', POSITIVE: 'text-green-700', NEGATIVE: 'text-red-700',
+                SECONDARY: 'text-gray-700', STANDARD: 'text-gray-900'
+              }[color] ?? 'text-blue-500'}
+              style={color.startsWith('#') ? { color } : undefined}
+            />
+          </svg>
+        )}
+      </Switch.Thumb>
     </Switch.Root>
   )
 
@@ -183,19 +198,15 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
       htmlFor={inputId}
       className={[
         labelSizeMap[size],
-        'font-medium text-gray-900 select-none',
+        'inline-flex items-center gap-1 font-medium text-gray-900 select-none',
         disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
       ].join(' ')}
     >
       {label}
-      {required && <span className="text-red-700 ml-1" aria-label="required">*</span>}
+      {required && <span className="text-red-700" aria-label="required">*</span>}
       {helpTooltip && (
-        <span
-          className="ml-2 text-gray-700 cursor-help"
-          title={helpTooltip}
-          aria-label="help"
-        >
-          ℹ️
+        <span className="text-gray-700 cursor-help inline-flex items-center" title={helpTooltip} aria-label="help">
+          <Info size={14} />
         </span>
       )}
     </label>

--- a/src/components/Switch/SwitchField.tsx
+++ b/src/components/Switch/SwitchField.tsx
@@ -89,15 +89,15 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
     },
     STANDARD: {
       root: 'h-6 w-11',
-      thumb: 'h-4 w-4 data-[state=checked]:translate-x-5'
+      thumb: 'h-4 w-4 data-[state=checked]:translate-x-5.5'
     },
     MEDIUM: {
       root: 'h-7 w-14',
-      thumb: 'h-5 w-5 data-[state=checked]:translate-x-7'
+      thumb: 'h-5 w-5 data-[state=checked]:translate-x-7.5'
     },
     LARGE: {
       root: 'h-9 w-18',
-      thumb: 'h-7 w-7 data-[state=checked]:translate-x-9'
+      thumb: 'h-7 w-7 data-[state=checked]:translate-x-9.5'
     }
   }
 

--- a/src/components/Tabs/TabsField.tsx
+++ b/src/components/Tabs/TabsField.tsx
@@ -129,12 +129,12 @@ export const TabsField: React.FC<TabsFieldProps> = ({
 
   // Active indicator color
   const indicatorColor = color.startsWith('#') ? color : {
-    ACCENT: 'var(--color-blue-500, #2322F0)',
-    POSITIVE: 'var(--color-green-700, #357A38)',
-    NEGATIVE: 'var(--color-red-700, #9B0027)',
-    SECONDARY: 'var(--color-gray-700, #616161)',
-    STANDARD: 'var(--color-gray-900, #212121)',
-  }[color] ?? 'var(--color-blue-500, #2322F0)'
+    ACCENT:    'var(--color-blue-500)',
+    POSITIVE:  'var(--color-green-700)',
+    NEGATIVE:  'var(--color-red-700)',
+    SECONDARY: 'var(--color-gray-700)',
+    STANDARD:  'var(--color-gray-900)',
+  }[color] ?? 'var(--color-blue-500)'
 
   // Container classes
   const sailClasses = [marginMap[marginAbove], marginBottomMap[marginBelow]].filter(Boolean).join(' ')

--- a/src/components/Tabs/TabsField.tsx
+++ b/src/components/Tabs/TabsField.tsx
@@ -68,6 +68,35 @@ export const TabsField: React.FC<TabsFieldProps> = ({
   activationMode = "AUTOMATIC",
   className
 }) => {
+  // Sliding indicator state
+  const [indicatorStyle, setIndicatorStyle] = React.useState<React.CSSProperties>({})
+  const listRef = React.useRef<HTMLDivElement>(null)
+  const [internalActive, setInternalActive] = React.useState(value ?? defaultValue ?? tabs[0]?.value)
+
+  const updateIndicator = React.useCallback(() => {
+    if (!listRef.current) return
+    const activeEl = listRef.current.querySelector<HTMLElement>('[data-state="active"]')
+    if (!activeEl) return
+    if (orientation === "HORIZONTAL") {
+      setIndicatorStyle({ left: activeEl.offsetLeft, width: activeEl.offsetWidth })
+    } else {
+      setIndicatorStyle({ top: activeEl.offsetTop, height: activeEl.offsetHeight })
+    }
+  }, [orientation])
+
+  // Update on mount and whenever active tab changes
+  React.useEffect(() => { updateIndicator() }, [internalActive, updateIndicator])
+
+  // Sync internalActive when controlled value changes
+  React.useEffect(() => {
+    if (value !== undefined) setInternalActive(value)
+  }, [value])
+
+  const handleValueChange = (val: string) => {
+    setInternalActive(val)
+    onValueChange?.(val)
+  }
+
   // Visibility control
   if (!showWhen) return null
 
@@ -90,48 +119,46 @@ export const TabsField: React.FC<TabsFieldProps> = ({
     EVEN_MORE: 'mb-8'
   }
 
-  // Size mappings for tab triggers
+  // Size mappings for tab triggers — matches ButtonWidget
   const sizeMap: Record<SAILSize, string> = {
-    SMALL: 'px-3 py-1.5 text-sm',
-    STANDARD: 'px-4 py-2.5 text-base',
-    MEDIUM: 'px-6 py-3 text-lg',
-    LARGE: 'px-8 py-4 text-xl'
+    SMALL: 'px-3 py-2 text-sm leading-none',
+    STANDARD: 'px-4 py-3 text-base leading-none',
+    MEDIUM: 'px-5 py-4 text-lg leading-none',
+    LARGE: 'px-6 py-5 text-xl leading-none'
   }
 
-  // Container classes
-  const sailClasses = [
-    marginMap[marginAbove],
-    marginBottomMap[marginBelow]
-  ].filter(Boolean).join(' ')
+  // Active indicator color
+  const indicatorColor = color.startsWith('#') ? color : {
+    ACCENT: 'var(--color-blue-500, #2322F0)',
+    POSITIVE: 'var(--color-green-700, #357A38)',
+    NEGATIVE: 'var(--color-red-700, #9B0027)',
+    SECONDARY: 'var(--color-gray-700, #616161)',
+    STANDARD: 'var(--color-gray-900, #212121)',
+  }[color] ?? 'var(--color-blue-500, #2322F0)'
 
+  // Container classes
+  const sailClasses = [marginMap[marginAbove], marginBottomMap[marginBelow]].filter(Boolean).join(' ')
   const containerClasses = mergeClasses(sailClasses, className)
 
-  // List classes based on orientation
-  const listClasses = orientation === "VERTICAL" 
-    ? "flex flex-col"
-    : "flex border-b border-gray-200"
+  const listClasses = orientation === "VERTICAL"
+    ? "relative flex flex-col"
+    : "relative flex"
 
-  // Content classes based on orientation
-  const contentClasses = orientation === "VERTICAL"
-    ? "pl-4 flex-1 p-4"
-    : "p-4"
-
-  // Root classes based on orientation
-  const rootClasses = orientation === "VERTICAL"
-    ? "flex"
-    : "block"
+  const contentClasses = orientation === "VERTICAL" ? "pl-4 flex-1 p-4" : "p-4"
+  const rootClasses = orientation === "VERTICAL" ? "flex" : "block"
 
   return (
     <div className={containerClasses}>
       <Tabs.Root
         value={value}
         defaultValue={defaultValue || tabs[0]?.value}
-        onValueChange={onValueChange}
+        onValueChange={handleValueChange}
         orientation={orientation.toLowerCase() as "horizontal" | "vertical"}
         activationMode={activationMode.toLowerCase() as "automatic" | "manual"}
         className={rootClasses}
       >
         <Tabs.List
+          ref={listRef}
           className={listClasses}
           loop={loop}
         >
@@ -142,24 +169,45 @@ export const TabsField: React.FC<TabsFieldProps> = ({
               disabled={tab.disabled}
               className={[
                 sizeMap[size],
-                'flex-1 bg-white text-gray-700 border-0 cursor-default select-none',
-                'items-center justify-center outline-none transition-colors hover:text-blue-500',
-                // Active state with underline shadow for horizontal, left border for vertical
-                orientation === "HORIZONTAL"
-                  ? 'data-[state=active]:text-blue-500 data-[state=active]:shadow-[inset_0_-2px_0_0] data-[state=active]:shadow-current'
-                  : 'data-[state=active]:text-blue-500 data-[state=active]:shadow-[inset_2px_0_0_0] data-[state=active]:shadow-current',
+                'relative bg-white text-gray-700 border-0 cursor-default select-none',
+                'flex items-center justify-center outline-none font-medium',
+                // Horizontal: bottom bar hover + active handled by slider
+                orientation === "HORIZONTAL" && 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:z-10 after:rounded-full after:bg-transparent after:transition-colors after:duration-200 hover:after:bg-gray-500 data-[state=active]:after:bg-transparent',
+                // Vertical: hover background + left bar hover
+                orientation === "VERTICAL" && 'hover:bg-gray-50 after:absolute after:left-0 after:top-0 after:h-full after:w-[2px] after:z-10 after:rounded-full after:bg-transparent after:transition-colors after:duration-200 hover:after:bg-gray-500 data-[state=active]:after:bg-transparent',
+                'data-[state=active]:font-semibold data-[state=active]:text-gray-900',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 'focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-blue-500'
               ].filter(Boolean).join(' ')}
-              style={
-                color.startsWith('#') && value === tab.value
-                  ? { color: color }
-                  : undefined
-              }
             >
               {tab.label}
             </Tabs.Trigger>
           ))}
+
+          {/* Full-width base line */}
+          {orientation === "HORIZONTAL" && (
+            <span aria-hidden="true" className="absolute bottom-0 left-0 w-full h-[2px] bg-gray-300 pointer-events-none" />
+          )}
+          {/* Sliding active segment — horizontal */}
+          {orientation === "HORIZONTAL" && (
+            <span
+              aria-hidden="true"
+              className="absolute bottom-0 h-[2px] rounded-full transition-all duration-300 ease-in-out pointer-events-none z-20"
+              style={{ ...indicatorStyle, backgroundColor: indicatorColor }}
+            />
+          )}
+          {/* Full-height base line — vertical */}
+          {orientation === "VERTICAL" && (
+            <span aria-hidden="true" className="absolute left-0 top-0 h-full w-[2px] bg-gray-300 pointer-events-none" />
+          )}
+          {/* Sliding active segment — vertical */}
+          {orientation === "VERTICAL" && (
+            <span
+              aria-hidden="true"
+              className="absolute left-0 w-[2px] rounded-full transition-all duration-300 ease-in-out pointer-events-none z-20"
+              style={{ ...indicatorStyle, backgroundColor: indicatorColor }}
+            />
+          )}
         </Tabs.List>
 
         {tabs.map((tab) => (

--- a/src/components/Tag/TagField.tsx
+++ b/src/components/Tag/TagField.tsx
@@ -98,9 +98,9 @@ export const TagField: React.FC<TagFieldProps> = ({
 
   // Semantic color mappings
   const bgColorMap: Record<SAILSemanticColor, string> = {
-    ACCENT: 'bg-blue-100',
-    POSITIVE: 'bg-green-100',
-    NEGATIVE: 'bg-red-100',
+    ACCENT: 'bg-blue-50',
+    POSITIVE: 'bg-green-50',
+    NEGATIVE: 'bg-red-50',
     SECONDARY: 'bg-gray-200',
     STANDARD: 'bg-gray-100'
   }
@@ -116,13 +116,15 @@ export const TagField: React.FC<TagFieldProps> = ({
   // Render individual tag
   const renderTag = (tag: TagItemProps, index: number) => {
     // Determine background color classes or inline styles
+    const semanticBg = (tag.backgroundColor as SAILSemanticColor) || 'ACCENT'
+
     const bgClass = tag.backgroundColor?.startsWith('#')
       ? ''
-      : bgColorMap[(tag.backgroundColor as SAILSemanticColor) || 'ACCENT']
+      : bgColorMap[semanticBg]
 
     const textClass = tag.textColor?.startsWith('#')
       ? ''
-      : textColorMap[(tag.textColor as SAILSemanticColor) || 'STANDARD']
+      : textColorMap[(tag.textColor as SAILSemanticColor) || semanticBg]
 
     const inlineStyle: React.CSSProperties = {
       ...(tag.backgroundColor?.startsWith('#') && { backgroundColor: tag.backgroundColor }),

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -155,7 +155,7 @@ export const TextField: React.FC<TextFieldProps> = ({
     // ReadOnly mode: no border, no background, no padding (inline display)
     readOnly && 'border-none bg-transparent p-0',
     // Normal mode: standard input styling
-    !readOnly && 'px-3 py-2 border border-gray-200 rounded-sm bg-white',
+    !readOnly && 'px-3 py-2 border border-gray-300 rounded-sm bg-white',
     !readOnly && 'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
     // Disabled state
     disabled && 'bg-gray-100 text-gray-700 cursor-not-allowed',

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
     label: 'Text Formatting',
     text: 'Bold',
     value: false,
-    style: 'OUTLINE',
+    style: 'SOLID',
   },
   render: (args) => {
     const [value, setValue] = useState(args.value)

--- a/src/components/Toggle/ToggleField.tsx
+++ b/src/components/Toggle/ToggleField.tsx
@@ -85,7 +85,7 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
   marginBelow = "STANDARD",
   size = "STANDARD",
   color = "ACCENT",
-  style = "OUTLINE",
+  style = "SOLID",
   icon,
   iconPosition = "START",
   className
@@ -111,33 +111,33 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
 
     if (style === "SOLID") {
       const solidColors: Record<typeof semanticColor, string> = {
-        ACCENT:    'border border-transparent bg-blue-500 text-white hover:bg-blue-700 data-[state=on]:bg-blue-700',
-        POSITIVE:  'border border-transparent bg-green-700 text-white hover:bg-green-900 data-[state=on]:bg-green-900',
-        NEGATIVE:  'border border-transparent bg-red-700 text-white hover:bg-red-900 data-[state=on]:bg-red-900',
-        SECONDARY: 'border border-transparent bg-gray-700 text-white hover:bg-gray-900 data-[state=on]:bg-gray-900',
-        STANDARD:  'border border-transparent bg-gray-900 text-white hover:bg-gray-700 data-[state=on]:bg-gray-700'
+        ACCENT:    'border border-blue-500 text-blue-500 bg-white hover:bg-blue-100 data-[state=on]:bg-blue-500 data-[state=on]:text-white data-[state=on]:border-transparent hover:data-[state=on]:bg-blue-500',
+        POSITIVE:  'border border-green-700 text-green-700 bg-white hover:bg-green-100 data-[state=on]:bg-green-700 data-[state=on]:text-white data-[state=on]:border-transparent hover:data-[state=on]:bg-green-700',
+        NEGATIVE:  'border border-red-700 text-red-700 bg-white hover:bg-red-100 data-[state=on]:bg-red-700 data-[state=on]:text-white data-[state=on]:border-transparent hover:data-[state=on]:bg-red-700',
+        SECONDARY: 'border border-gray-700 text-gray-700 bg-white hover:bg-gray-100 data-[state=on]:bg-gray-700 data-[state=on]:text-white data-[state=on]:border-transparent hover:data-[state=on]:bg-gray-700',
+        STANDARD:  'border border-gray-900 text-gray-900 bg-white hover:bg-gray-200 data-[state=on]:bg-gray-900 data-[state=on]:text-white data-[state=on]:border-transparent hover:data-[state=on]:bg-gray-900'
       }
       return solidColors[semanticColor]
     }
 
     if (style === "OUTLINE") {
       const outlineColors: Record<typeof semanticColor, string> = {
-        ACCENT:    'border border-blue-500 text-blue-500 bg-white hover:bg-blue-100 data-[state=on]:bg-blue-100 data-[state=on]:border-blue-700 data-[state=on]:text-blue-700',
-        POSITIVE:  'border border-green-700 text-green-700 bg-white hover:bg-green-100 data-[state=on]:bg-green-100 data-[state=on]:border-green-900 data-[state=on]:text-green-900',
-        NEGATIVE:  'border border-red-700 text-red-700 bg-white hover:bg-red-100 data-[state=on]:bg-red-100 data-[state=on]:border-red-900 data-[state=on]:text-red-900',
-        SECONDARY: 'border border-gray-700 text-gray-700 bg-white hover:bg-gray-100 data-[state=on]:bg-gray-100 data-[state=on]:border-gray-900 data-[state=on]:text-gray-900',
-        STANDARD:  'border border-gray-900 text-gray-900 bg-white hover:bg-gray-100 data-[state=on]:bg-gray-100'
+        ACCENT:    'border border-blue-500 text-blue-500 bg-white hover:bg-blue-100 data-[state=on]:bg-blue-50',
+        POSITIVE:  'border border-green-700 text-green-700 bg-white hover:bg-green-100 data-[state=on]:bg-green-50',
+        NEGATIVE:  'border border-red-700 text-red-700 bg-white hover:bg-red-100 data-[state=on]:bg-red-50',
+        SECONDARY: 'border border-gray-700 text-gray-700 bg-white hover:bg-gray-100 data-[state=on]:bg-gray-50',
+        STANDARD:  'border border-gray-900 text-gray-900 bg-white hover:bg-gray-200 data-[state=on]:bg-gray-50'
       }
       return outlineColors[semanticColor]
     }
 
     if (style === "GHOST") {
       const ghostColors: Record<typeof semanticColor, string> = {
-        ACCENT:    'border border-transparent text-blue-500 hover:bg-blue-100 data-[state=on]:bg-blue-100 data-[state=on]:border-blue-200',
-        POSITIVE:  'border border-transparent text-green-700 hover:bg-green-100 data-[state=on]:bg-green-100 data-[state=on]:border-green-200',
-        NEGATIVE:  'border border-transparent text-red-700 hover:bg-red-100 data-[state=on]:bg-red-100 data-[state=on]:border-red-200',
-        SECONDARY: 'border border-transparent text-gray-700 hover:bg-gray-100 data-[state=on]:bg-gray-100 data-[state=on]:border-gray-200',
-        STANDARD:  'border border-transparent text-gray-900 hover:bg-gray-100 data-[state=on]:bg-gray-100 data-[state=on]:border-gray-200'
+        ACCENT:    'border border-transparent text-blue-500 hover:bg-blue-100 data-[state=on]:bg-blue-50',
+        POSITIVE:  'border border-transparent text-green-700 hover:bg-green-100 data-[state=on]:bg-green-50',
+        NEGATIVE:  'border border-transparent text-red-700 hover:bg-red-100 data-[state=on]:bg-red-50',
+        SECONDARY: 'border border-transparent text-gray-700 hover:bg-gray-100 data-[state=on]:bg-gray-50',
+        STANDARD:  'border border-transparent text-gray-900 hover:bg-gray-200 data-[state=on]:bg-gray-50'
       }
       return ghostColors[semanticColor]
     }
@@ -208,7 +208,7 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
       className={[
         'inline-flex items-center justify-center gap-1',
         'font-medium transition-colors h-auto rounded-sm',
-        'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
         sizeMap[size],
         getColorClasses(),
         disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'

--- a/src/components/Toggle/ToggleField.tsx
+++ b/src/components/Toggle/ToggleField.tsx
@@ -54,7 +54,7 @@ export interface ToggleFieldProps {
   /** Size of the toggle button */
   size?: SAILSize
   /** Color when toggle is pressed (hex or semantic) */
-  color?: "ACCENT" | "POSITIVE" | "NEGATIVE" | "SECONDARY" | string
+  color?: "ACCENT" | "POSITIVE" | "NEGATIVE" | "SECONDARY" | "STANDARD" | string
   /** Determines the button's appearance */
   style?: ToggleStyle
   /** Icon to display in the button */
@@ -95,49 +95,49 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
 
   const inputId = `togglefield-${Math.random().toString(36).substr(2, 9)}`
 
-  // Size mappings (same as ButtonWidget)
+  // Size mappings — matches ButtonWidget exactly
   const sizeMap: Record<SAILSize, string> = {
-    SMALL: 'px-3 py-1.5 text-sm',
-    STANDARD: 'px-4 py-2.5 text-base',
-    MEDIUM: 'px-6 py-3 text-lg',
-    LARGE: 'px-8 py-4 text-xl'
+    SMALL: 'px-3 py-2 text-sm leading-none',
+    STANDARD: 'px-4 py-3 text-base leading-none',
+    MEDIUM: 'px-5 py-4 text-lg leading-none',
+    LARGE: 'px-6 py-5 text-xl leading-none'
   }
 
   // Get color classes based on style and pressed state
   const getColorClasses = (): string => {
-    // Handle hex colors
-    if (color.startsWith('#')) {
-      return style === "SOLID" ? 'border-2' : 'border-2'
-    }
+    if (color.startsWith('#')) return 'border'
 
-    const semanticColor = color as "ACCENT" | "POSITIVE" | "NEGATIVE" | "SECONDARY"
+    const semanticColor = color as "ACCENT" | "POSITIVE" | "NEGATIVE" | "SECONDARY" | "STANDARD"
 
     if (style === "SOLID") {
       const solidColors: Record<typeof semanticColor, string> = {
-        ACCENT: 'border-2 border-blue-500 bg-white text-blue-500 data-[state=on]:bg-blue-500 data-[state=on]:text-white data-[state=on]:border-blue-500 hover:bg-blue-50 data-[state=on]:hover:bg-blue-700',
-        POSITIVE: 'border-2 border-green-700 bg-white text-green-700 data-[state=on]:bg-green-700 data-[state=on]:text-white data-[state=on]:border-green-700 hover:bg-green-50 data-[state=on]:hover:bg-green-900',
-        NEGATIVE: 'border-2 border-red-700 bg-white text-red-700 data-[state=on]:bg-red-700 data-[state=on]:text-white data-[state=on]:border-red-700 hover:bg-red-50 data-[state=on]:hover:bg-red-900',
-        SECONDARY: 'border-2 border-gray-700 bg-white text-gray-700 data-[state=on]:bg-gray-700 data-[state=on]:text-white data-[state=on]:border-gray-700 hover:bg-gray-50 data-[state=on]:hover:bg-gray-900'
+        ACCENT:    'border border-transparent bg-blue-500 text-white hover:bg-blue-700 data-[state=on]:bg-blue-700',
+        POSITIVE:  'border border-transparent bg-green-700 text-white hover:bg-green-900 data-[state=on]:bg-green-900',
+        NEGATIVE:  'border border-transparent bg-red-700 text-white hover:bg-red-900 data-[state=on]:bg-red-900',
+        SECONDARY: 'border border-transparent bg-gray-700 text-white hover:bg-gray-900 data-[state=on]:bg-gray-900',
+        STANDARD:  'border border-transparent bg-gray-900 text-white hover:bg-gray-700 data-[state=on]:bg-gray-700'
       }
       return solidColors[semanticColor]
     }
 
     if (style === "OUTLINE") {
       const outlineColors: Record<typeof semanticColor, string> = {
-        ACCENT: 'border-2 border-blue-500 text-blue-500 bg-white data-[state=on]:bg-blue-100 hover:bg-blue-50',
-        POSITIVE: 'border-2 border-green-700 text-green-700 bg-white data-[state=on]:bg-green-100 hover:bg-green-50',
-        NEGATIVE: 'border-2 border-red-700 text-red-700 bg-white data-[state=on]:bg-red-100 hover:bg-red-50',
-        SECONDARY: 'border-2 border-gray-700 text-gray-700 bg-white data-[state=on]:bg-gray-100 hover:bg-gray-50'
+        ACCENT:    'border border-blue-500 text-blue-500 bg-white hover:bg-blue-100 data-[state=on]:bg-blue-100 data-[state=on]:border-blue-700 data-[state=on]:text-blue-700',
+        POSITIVE:  'border border-green-700 text-green-700 bg-white hover:bg-green-100 data-[state=on]:bg-green-100 data-[state=on]:border-green-900 data-[state=on]:text-green-900',
+        NEGATIVE:  'border border-red-700 text-red-700 bg-white hover:bg-red-100 data-[state=on]:bg-red-100 data-[state=on]:border-red-900 data-[state=on]:text-red-900',
+        SECONDARY: 'border border-gray-700 text-gray-700 bg-white hover:bg-gray-100 data-[state=on]:bg-gray-100 data-[state=on]:border-gray-900 data-[state=on]:text-gray-900',
+        STANDARD:  'border border-gray-900 text-gray-900 bg-white hover:bg-gray-100 data-[state=on]:bg-gray-100'
       }
       return outlineColors[semanticColor]
     }
 
     if (style === "GHOST") {
       const ghostColors: Record<typeof semanticColor, string> = {
-        ACCENT: 'border-2 border-transparent text-blue-500 bg-transparent data-[state=on]:bg-blue-100 hover:bg-blue-50',
-        POSITIVE: 'border-2 border-transparent text-green-700 bg-transparent data-[state=on]:bg-green-100 hover:bg-green-50',
-        NEGATIVE: 'border-2 border-transparent text-red-700 bg-transparent data-[state=on]:bg-red-100 hover:bg-red-50',
-        SECONDARY: 'border-2 border-transparent text-gray-700 bg-transparent data-[state=on]:bg-gray-100 hover:bg-gray-50'
+        ACCENT:    'border border-transparent text-blue-500 hover:bg-blue-100 data-[state=on]:bg-blue-100 data-[state=on]:border-blue-200',
+        POSITIVE:  'border border-transparent text-green-700 hover:bg-green-100 data-[state=on]:bg-green-100 data-[state=on]:border-green-200',
+        NEGATIVE:  'border border-transparent text-red-700 hover:bg-red-100 data-[state=on]:bg-red-100 data-[state=on]:border-red-200',
+        SECONDARY: 'border border-transparent text-gray-700 hover:bg-gray-100 data-[state=on]:bg-gray-100 data-[state=on]:border-gray-200',
+        STANDARD:  'border border-transparent text-gray-900 hover:bg-gray-100 data-[state=on]:bg-gray-100 data-[state=on]:border-gray-200'
       }
       return ghostColors[semanticColor]
     }
@@ -206,8 +206,9 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
       onPressedChange={handleChange}
       disabled={disabled}
       className={[
-        'inline-flex items-center justify-center gap-2',
-        'font-medium transition-colors rounded-sm',
+        'inline-flex items-center justify-center gap-1',
+        'font-medium transition-colors h-auto rounded-sm',
+        'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
         sizeMap[size],
         getColorClasses(),
         disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'


### PR DESCRIPTION
Update Toggle, TextField, Tag, Tab, and Switch to align with new studio color palette. Includes animation update for Tab and UI update for Switch.

**Toggle:** 
- match Button

**TextField:** 
- Updated border color to use gray-300
<img width="1018" height="392" alt="Screenshot 2026-04-23 at 14 57 48" src="https://github.com/user-attachments/assets/2b079ee2-d2a3-4bd6-b56e-824a24f2daf4" />

**Tag**
- Updated background color for semantic tags to use .50 variant
<img width="696" height="652" alt="Screenshot 2026-04-23 at 14 54 22" src="https://github.com/user-attachments/assets/534cf19b-9eff-466e-ad98-620ac4e2ac69" />

**Tab**
- Update size mapping (match Button)
- Update border color to use 300 variant
- Add sliding animation to tabs
- Fixed tab highlight to not sit above the horizontal line
- Give vertical tab animated slider (upcoming release from TX)
https://github.com/user-attachments/assets/de389bab-0892-44b2-b85d-68021b5f637b

**Switch**
- Add hover state for off state (hover:bg-gray-100)
- Change circle (thumb) size to fit the track with padding
- Add check icon to on state
- Update off state track: white bg + gray-300 border (was dark gray-500/gray-700)
- Add circle border (gray-500 off, transparent on)
- Add SECONDARY and STANDARD color support
https://github.com/user-attachments/assets/d9e51893-1bee-4ab5-9df3-0d62a35a83fa
- Replace ℹ️ emoji with Lucide Info icon
- Update label to inline-flex items-center gap-1 so text, asterisk, and info icon
all align on the same baseline
<img width="1018" height="392" alt="Screenshot 2026-04-23 at 15 02 14" src="https://github.com/user-attachments/assets/c49a6e3e-7769-4d7b-a1a9-f94706e2f206" />
