### PR TITLE
feat: add RecordView template with SiteNav and pill tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-switch": "^1.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-progress':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -651,6 +654,21 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -736,6 +754,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-avatar@1.1.10':
     resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
     peerDependencies:
@@ -815,6 +846,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -844,6 +888,32 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-portal@1.1.9':
@@ -1035,6 +1105,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
@@ -1043,6 +1122,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.38':
     resolution: {integrity: sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==}
@@ -3496,6 +3578,23 @@ snapshots:
 
   '@exodus/bytes@1.14.1': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3598,6 +3697,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
   '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.0)(react@19.2.0)
@@ -3676,6 +3784,21 @@ snapshots:
       '@types/react': 19.2.0
       '@types/react-dom': 19.2.0(@types/react@19.2.0)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.0)(react@19.2.0)':
     dependencies:
       react: 19.2.0
@@ -3699,6 +3822,50 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.0
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.1(@types/react@19.2.0)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -3871,12 +4038,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.0
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.0)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.0
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.38': {}
 

--- a/src/components/RecordView/RecordView.stories.tsx
+++ b/src/components/RecordView/RecordView.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { RecordView } from './RecordView'
+import type { RecordAction, RecordViewProps } from './RecordView'
+import type { SiteNavPage } from '../SiteNav'
+import {
+  Home,
+  List,
+  Inbox,
+  FolderOpen,
+  BarChart3,
+  Search,
+  MessagesSquare,
+} from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { CardLayout } from '../Card/CardLayout'
+import { HeadingField } from '../Heading/HeadingField'
+import { RichTextDisplayField } from '../RichText/RichTextDisplayField'
+import { TextItem } from '../RichText/TextItem'
+
+/** Shared render function that wires up stateful view switching */
+const InteractiveRender = (args: RecordViewProps) => {
+  const [viewIndex, setViewIndex] = useState(args.selectedViewIndex ?? 0)
+
+  useEffect(() => {
+    setViewIndex(args.selectedViewIndex ?? 0)
+  }, [args.selectedViewIndex])
+
+  return (
+    <RecordView {...args} selectedViewIndex={viewIndex} onViewChange={setViewIndex} />
+  )
+}
+
+const meta = {
+  title: 'Templates/RecordView',
+  component: RecordView,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  render: InteractiveRender,
+} satisfies Meta<typeof RecordView>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const sitePages: SiteNavPage[] = [
+  { label: 'Home', icon: Home },
+  { label: 'Records', icon: List, isSelected: true },
+  { label: 'Inbox', icon: Inbox, badge: '(3)' },
+  {
+    label: 'Directory',
+    icon: FolderOpen,
+    isGroup: true,
+    children: [
+      { label: 'People' },
+      { label: 'Teams' },
+    ],
+  },
+  { label: 'Reports', icon: BarChart3 },
+  { label: 'Search', icon: Search },
+  { label: 'Chat', icon: MessagesSquare },
+]
+
+const recordActions: RecordAction[] = [
+  { label: 'EDIT' },
+  { label: 'APPROVE' },
+  { label: 'EXPORT' },
+  { label: 'Archive' },
+  { label: 'Delete' },
+]
+
+const recordViews = [
+  { label: 'Summary', content: (
+    <div className="p-6">
+      <CardLayout padding="STANDARD">
+        <HeadingField text="Overview" size="MEDIUM" marginBelow="LESS" fontWeight="SEMI_BOLD" />
+        <RichTextDisplayField value={["This is the summary view content."]} />
+      </CardLayout>
+    </div>
+  )},
+  { label: 'Details', content: (
+    <div className="p-6">
+      <CardLayout padding="STANDARD">
+        <HeadingField text="Record Details" size="MEDIUM" marginBelow="LESS" fontWeight="SEMI_BOLD" />
+        <RichTextDisplayField value={["This is the details view content."]} />
+      </CardLayout>
+    </div>
+  )},
+  { label: 'Activity', content: (
+    <div className="p-6">
+      <RichTextDisplayField value={[<TextItem key="activity" text="No recent activity." color="SECONDARY" />]} />
+    </div>
+  )},
+  { label: 'Documents' },
+  { label: 'History' },
+]
+
+export const Default: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    recordTitle: 'REC-001 | Sample Record',
+    recordActions,
+    views: recordViews,
+    userName: 'Jane Doe',
+    selectedViewIndex: 0,
+  },
+}
+
+export const CollapsedNav: Story = {
+  args: {
+    ...Default.args,
+    collapsed: true,
+  },
+}
+
+export const MinimalRecord: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: [{ label: 'Home', icon: Home, isSelected: true }],
+    recordTitle: 'Case #12345',
+    recordActions: [{ label: 'EDIT' }],
+    views: [{ label: 'Summary' }, { label: 'History' }],
+    userName: 'Alex Brown',
+    selectedViewIndex: 0,
+  },
+}
+
+export const NoActions: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    recordTitle: 'Read-Only Record',
+    recordActions: [],
+    views: [{ label: 'Summary' }, { label: 'Details' }],
+    userName: 'Jane Doe',
+    selectedViewIndex: 0,
+  },
+}
+
+export const ManyActions: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    recordTitle: 'REC-002 | Record With Many Actions',
+    recordActions: [
+      { label: 'UPDATE' },
+      { label: 'CREATE DOCUMENT' },
+      { label: 'UPLOAD DOCUMENTS' },
+      { label: 'Submit for Review' },
+      { label: 'Submit to Contracting' },
+      { label: 'Mark Inactive' },
+      { label: 'Copy Record' },
+    ],
+    views: recordViews,
+    userName: 'Jane Doe',
+    selectedViewIndex: 0,
+  },
+}

--- a/src/components/RecordView/RecordView.tsx
+++ b/src/components/RecordView/RecordView.tsx
@@ -1,0 +1,219 @@
+import * as React from 'react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { SiteNav } from '../SiteNav'
+import type { SiteNavPage } from '../SiteNav'
+import type { SAILSemanticColor } from '../../types/sail'
+import { ButtonArrayLayout } from '../Button/ButtonArrayLayout'
+import { ButtonWidget } from '../Button/ButtonWidget'
+import { TabsField } from '../Tabs'
+import { HeadingField } from '../Heading/HeadingField'
+
+/** Active tab color */
+const ACTIVE_TAB_COLOR = 'ACCENT'
+
+/**
+ * Record action button configuration.
+ */
+export interface RecordAction {
+  /** Button label */
+  label: string
+  /** Click handler */
+  onClick?: () => void
+}
+
+/**
+ * Record view tab configuration.
+ */
+export interface RecordViewTab {
+  /** Tab label */
+  label: string
+  /** Content to display when this view is active */
+  content?: React.ReactNode
+  /** Whether this tab is the active view. Ignored when selectedViewIndex is provided on RecordView. */
+  isSelected?: boolean
+  /** Click handler */
+  onClick?: () => void
+}
+
+/**
+ * Props for the RecordView template.
+ * Composes SiteNav + record header + view tabs + content slot.
+ */
+export interface RecordViewProps {
+  /* --- Site Nav props --- */
+  /** Site/solution display name */
+  displayName?: string
+  /** Site pages for the left nav */
+  pages: SiteNavPage[]
+  /** Controlled collapsed state */
+  collapsed?: boolean
+  /** Collapse toggle callback */
+  onCollapseToggle?: (collapsed: boolean) => void
+  /** User full name */
+  userName?: string
+  /** Appian logo path */
+  appianLogoSrc?: string
+  /** Highlight color for selected nav item (passed to SiteNav) */
+  highlightColor?: SAILSemanticColor | string
+
+  /* --- Record header props --- */
+  /** Record title (e.g. "REC-001 | Sample Record") */
+  recordTitle: string
+  /** Record action buttons shown in the record header. First 3 are shown as buttons; extras appear in an overflow dropdown. */
+  recordActions?: RecordAction[]
+  /** Record view tabs */
+  views?: RecordViewTab[]
+  /** Index of the currently selected view (controlled). When provided, overrides isSelected on individual tabs. */
+  selectedViewIndex?: number
+  /** Callback when a view tab is clicked. Receives the index of the clicked tab. */
+  onViewChange?: (index: number) => void
+
+  /* --- Content slot --- */
+  /** Content to render inside the active view area. This is the slot UXDs fill in. */
+  children?: React.ReactNode
+}
+
+/** Maximum number of action buttons shown before overflow */
+const MAX_VISIBLE_ACTIONS = 3
+
+/** Renders record action buttons with overflow dropdown. */
+const RecordActions: React.FC<{ actions: RecordAction[] }> = ({ actions }) => {
+  const visibleActions = actions.slice(0, MAX_VISIBLE_ACTIONS)
+  const overflowActions = actions.slice(MAX_VISIBLE_ACTIONS)
+
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <ButtonArrayLayout
+        buttons={visibleActions.map((action) => ({
+          label: action.label,
+          style: 'OUTLINE' as const,
+          color: 'ACCENT',
+          size: 'SMALL' as const,
+          onClick: action.onClick,
+        }))}
+        marginBelow="NONE"
+      />
+      {overflowActions.length > 0 && (
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <div>
+              <ButtonWidget
+                icon="ellipsis"
+                style="OUTLINE"
+                color="ACCENT"
+                size="SMALL"
+                accessibilityText="More actions"
+                tooltip="More actions"
+              />
+            </div>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              className="bg-white border border-gray-200 rounded-sm shadow-lg z-10 min-w-48"
+              align="end"
+              sideOffset={4}
+            >
+              {overflowActions.map((action) => (
+                <DropdownMenu.Item
+                  key={action.label}
+                  onSelect={() => action.onClick?.()}
+                  className="block w-full text-left px-4 py-2.5 text-sm text-gray-800 hover:bg-gray-100 transition-colors cursor-pointer outline-none data-[highlighted]:bg-gray-100"
+                >
+                  {action.label}
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      )}
+    </div>
+  )
+}
+
+/**
+ * RecordView Template
+ * Maps to SAIL's a!navigationLayout (SIDEBAR) wrapping a!headerContentLayout.
+ */
+export const RecordView: React.FC<RecordViewProps> = ({
+  // Site nav
+  displayName,
+  pages,
+  collapsed,
+  onCollapseToggle,
+  userName,
+  appianLogoSrc,
+  highlightColor,
+
+  // Record header
+  recordTitle,
+  recordActions = [],
+  views = [],
+  selectedViewIndex,
+  onViewChange,
+
+  // Content
+  children,
+}) => {
+  return (
+    <div className="flex h-screen w-full overflow-hidden bg-gray-50">
+      {/* Left: Site Navigation */}
+      <SiteNav
+        displayName={displayName}
+        pages={pages}
+        collapsed={collapsed}
+        onCollapseToggle={onCollapseToggle}
+        userName={userName}
+        appianLogoSrc={appianLogoSrc}
+        highlightColor={highlightColor}
+      />
+
+      {/* Right: Record content area */}
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        {/* Record header: title + actions */}
+        <div className="flex items-center justify-between px-6 pt-3 pb-2 bg-gray-50 shrink-0">
+          <div className="truncate mr-4">
+            <HeadingField text={recordTitle} size="LARGE_PLUS" marginBelow="NONE" fontWeight="SEMI_BOLD" />
+          </div>
+
+          {recordActions.length > 0 && (
+            <RecordActions actions={recordActions} />
+          )}
+        </div>
+
+        {/* Record view tabs + content */}
+        {views.length > 0 && (
+          <div className="px-6 pt-1.5 pb-3 bg-gray-50 shrink-0">
+            <TabsField
+              tabs={views.map((view, index) => ({
+                value: String(index),
+                label: view.label,
+                content: view.content ?? null,
+              }))}
+              value={selectedViewIndex !== undefined ? String(selectedViewIndex) : undefined}
+              defaultValue="0"
+              onValueChange={(val) => {
+                const idx = Number(val)
+                onViewChange?.(idx)
+                views[idx]?.onClick?.()
+              }}
+              variant="PILL"
+              size="SMALL"
+              color={ACTIVE_TAB_COLOR}
+              marginAbove="NONE"
+              marginBelow="NONE"
+            />
+          </div>
+        )}
+
+        {/* Content slot */}
+        <div className="flex-1 overflow-y-auto bg-gray-50">
+          {children || (
+            <div className="p-6 text-gray-400 text-sm">
+              Record view content goes here. Replace this with your view components.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/RecordView/index.ts
+++ b/src/components/RecordView/index.ts
@@ -1,0 +1,6 @@
+export { RecordView } from './RecordView'
+export type {
+  RecordViewProps,
+  RecordAction,
+  RecordViewTab,
+} from './RecordView'

--- a/src/components/SiteNav/SiteNav.stories.tsx
+++ b/src/components/SiteNav/SiteNav.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { SiteNav } from './SiteNav'
+import type { SiteNavPage } from './SiteNav'
+import {
+  Home,
+  List,
+  Inbox,
+  FolderOpen,
+  FileText,
+  BarChart3,
+  Search,
+  MessagesSquare,
+} from 'lucide-react'
+
+const meta = {
+  title: 'Components/SiteNav',
+  component: SiteNav,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh', display: 'flex' }}>
+        <Story />
+        <div style={{ flex: 1, background: '#f5f5f5', padding: '1rem' }}>
+          <p style={{ color: '#666' }}>Page content area</p>
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SiteNav>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const sitePages: SiteNavPage[] = [
+  { label: 'Home', icon: Home },
+  { label: 'Records', icon: List, isSelected: true },
+  { label: 'Inbox', icon: Inbox, badge: '(3)' },
+  {
+    label: 'Directory',
+    icon: FolderOpen,
+    isGroup: true,
+    children: [
+      { label: 'People' },
+      { label: 'Teams' },
+    ],
+  },
+  { label: 'Reports', icon: BarChart3 },
+  { label: 'Search', icon: Search },
+  { label: 'Chat', icon: MessagesSquare },
+]
+
+export const Default: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    userName: 'Jane Doe',
+  },
+}
+
+export const Collapsed: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    collapsed: true,
+    userName: 'Jane Doe',
+  },
+}
+
+export const WithGroupExpanded: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: [
+      { label: 'Home', icon: Home },
+      { label: 'Records', icon: List },
+      {
+        label: 'Directory',
+        icon: FolderOpen,
+        isGroup: true,
+        children: [
+          { label: 'People', isSelected: true },
+          { label: 'Teams' },
+        ],
+      },
+      { label: 'Reports', icon: BarChart3 },
+    ],
+    userName: 'Jane Doe',
+  },
+}
+
+export const MinimalPages: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: [
+      { label: 'Home', icon: Home, isSelected: true },
+      { label: 'Documents', icon: FileText },
+    ],
+    userName: 'Alex Brown',
+  },
+}
+
+
+export const Hidden: Story = {
+  args: {
+    displayName: 'My Application',
+    pages: sitePages,
+    showNavigation: false,
+    userName: 'Jane Doe',
+  },
+}

--- a/src/components/SiteNav/SiteNav.tsx
+++ b/src/components/SiteNav/SiteNav.tsx
@@ -1,0 +1,313 @@
+import * as React from 'react'
+import {
+  ChevronRight,
+  ChevronLeft,
+  LayoutGrid,
+  type LucideIcon,
+} from 'lucide-react'
+import { ImageField } from '../Image/ImageField'
+import type { SAILSemanticColor } from '../../types/sail'
+
+/**
+ * Represents a single page/tab in the site navigation.
+ * Maps to SAIL's NavigationNode / NavigationMenuTab types.
+ */
+export interface SiteNavPage {
+  /** Display text for the page (maps to NavigationNode.name / NavigationMenuTab.label) */
+  label: string
+  /** Lucide icon component (maps to NavigationNode.icon / NavigationMenuTab.iconFriendlyName) */
+  icon?: LucideIcon
+  /** Whether this page is currently active (maps to NavigationMenuTab.isSelected) */
+  isSelected?: boolean
+  /** Whether this is a group with children (maps to NavigationNode.isGroup) */
+  isGroup?: boolean
+  /** Sub-pages for grouped navigation (maps to NavigationNode.children) */
+  children?: SiteNavPage[]
+  /** Optional badge text, e.g. "(1)" for unread count */
+  badge?: string
+  /** Callback when page is clicked */
+  onClick?: () => void
+}
+
+/**
+ * Props for the SiteNav component.
+ * Maps to SAIL's a!navigationLayout with primaryNavLayoutType="SIDEBAR".
+ */
+export interface SiteNavProps {
+  /** Site/solution display name (maps to NavigationLayout.displayName) */
+  displayName?: string
+  /** Array of site pages (maps to NavigationLayout.tabs / NavigationNode[]) */
+  pages: SiteNavPage[]
+  /** Controlled collapsed state */
+  collapsed?: boolean
+  /** Callback when collapse toggle is clicked */
+  onCollapseToggle?: (collapsed: boolean) => void
+  /** Whether to show the navigation (maps to NavigationLayout.showNavigation) */
+  showNavigation?: boolean
+  /** User full name — initials are derived automatically */
+  userName?: string
+  /** Path to Appian logo image */
+  appianLogoSrc?: string
+  /** Background color for the selected/highlighted page. Accepts hex or semantic color. Default: "POSITIVE" */
+  highlightColor?: SAILSemanticColor | string
+}
+
+
+/**
+ * SiteNav Component
+ *
+ * Renders the sidebar navigation for an Appian site.
+ * Maps to SAIL's a!navigationLayout with primaryNavLayoutType="SIDEBAR".
+ */
+export const SiteNav: React.FC<SiteNavProps> = ({
+  displayName,
+  pages,
+  collapsed: controlledCollapsed,
+  onCollapseToggle,
+  showNavigation = true,
+  userName,
+  appianLogoSrc = 'images/icon-appian-header.png',
+  highlightColor = 'POSITIVE',
+}) => {
+  const [internalCollapsed, setInternalCollapsed] = React.useState(false)
+
+  const isCollapsed = controlledCollapsed ?? internalCollapsed
+
+  // Highlight color mappings
+  const semanticHighlightMap: Record<SAILSemanticColor, string> = {
+    ACCENT: 'bg-blue-100',
+    POSITIVE: 'bg-green-100',
+    NEGATIVE: 'bg-red-100',
+    SECONDARY: 'bg-gray-100',
+    STANDARD: 'bg-gray-200',
+  }
+  const isHexHighlight = highlightColor.startsWith('#')
+  const highlightClass = !isHexHighlight ? (semanticHighlightMap[highlightColor as SAILSemanticColor] || semanticHighlightMap.POSITIVE) : ''
+  const highlightStyle = isHexHighlight ? { backgroundColor: highlightColor } : undefined
+
+  const userInitials = userName
+    ? userName.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)
+    : 'U'
+
+  const toggleCollapse = () => {
+    const next = !isCollapsed
+    setInternalCollapsed(next)
+    onCollapseToggle?.(next)
+  }
+
+  if (!showNavigation) return null
+
+  return (
+      <nav
+        className={`flex flex-col h-full bg-white transition-all duration-200 shrink-0 ${
+          isCollapsed ? 'w-16' : 'w-[240px]'
+        }`}
+        aria-label="Site navigation"
+      >
+        {/* Logo + waffle menu */}
+        {!isCollapsed ? (
+          <div className="flex items-center justify-between px-4 pt-4 pb-6 shrink-0">
+            <img
+              src={appianLogoSrc}
+              alt="Appian"
+              className="h-8 w-auto -mb-0.5"
+            />
+            {/* Waffle menu (decorative) */}
+            <button
+              className="flex items-center justify-center w-8 h-8 text-gray-700 hover:bg-gray-100 rounded-sm transition-colors"
+              aria-label="Navigation menu"
+              title="Navigation menu"
+            >
+              <LayoutGrid className="w-5 h-5" />
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center pt-3 pb-6 shrink-0">
+            <img
+              src={appianLogoSrc}
+              alt="Appian"
+              className="h-4 w-auto"
+            />
+          </div>
+        )}
+
+        {/* Site name */}
+        {!isCollapsed && displayName && (
+          <div className="px-4 pb-3">
+            <span className="text-lg font-semibold text-gray-900 leading-tight whitespace-pre-line">
+              {displayName}
+            </span>
+          </div>
+        )}
+
+        {/* Page list */}
+        <ul className="flex-1 list-none m-0 px-2 py-0 overflow-y-auto" role="list">
+          {pages.map((page) => (
+            <SiteNavItem
+              key={page.label}
+              page={page}
+              isCollapsed={isCollapsed}
+              highlightClass={highlightClass}
+              highlightStyle={highlightStyle}
+            />
+          ))}
+        </ul>
+
+        {/* Bottom section */}
+        <div className="flex flex-col shrink-0">
+          {isCollapsed ? (
+            <div className="flex flex-col items-center gap-3 py-4">
+              {/* Waffle menu (decorative) */}
+              <button
+                className="flex items-center justify-center w-8 h-8 text-gray-700 hover:bg-gray-100 rounded-sm transition-colors"
+                aria-label="Navigation menu"
+                title="Navigation menu"
+              >
+                <LayoutGrid className="w-5 h-5" />
+              </button>
+
+              <ImageField
+                images={[{
+                  imageType: 'user' as const,
+                  user: { name: userName || userInitials, initials: userInitials },
+                  altText: userName || userInitials,
+                }]}
+                style="AVATAR"
+                size="ICON_PLUS"
+                marginBelow="NONE"
+              />
+
+              <button
+                onClick={toggleCollapse}
+                className="flex items-center justify-center w-8 h-8 rounded bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors"
+                aria-label="Expand navigation"
+                title="Expand navigation"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          ) : (
+              <div className="flex items-center pl-4 py-4">
+                <ImageField
+                  images={[{
+                    imageType: 'user' as const,
+                    user: { name: userName || userInitials, initials: userInitials },
+                    altText: userName || userInitials,
+                  }]}
+                  style="AVATAR"
+                  size="ICON_PLUS"
+                  marginBelow="NONE"
+                />
+                <span className="ml-3 text-sm font-medium text-gray-800 truncate flex-1">
+                  {userName || userInitials}
+                </span>
+                <button
+                  onClick={toggleCollapse}
+                  className="flex items-center justify-center w-8 h-8 rounded-l bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors shrink-0"
+                  aria-label="Collapse navigation"
+                  title="Collapse navigation"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </button>
+              </div>
+          )}
+        </div>
+      </nav>
+  )
+}
+
+/**
+ * SiteNavItem — renders a single navigation item (page or group).
+ */
+const SiteNavItem: React.FC<{
+  page: SiteNavPage
+  isCollapsed: boolean
+  highlightClass: string
+  highlightStyle?: React.CSSProperties
+  depth?: number
+}> = ({ page, isCollapsed, highlightClass, highlightStyle, depth = 0 }) => {
+  const [expanded, setExpanded] = React.useState(
+    // Auto-expand if any child is selected
+    page.children?.some((c) => c.isSelected) ?? false
+  )
+
+  const IconComponent = page.icon
+  const hasChildren = page.isGroup || (page.children && page.children.length > 0)
+
+  const handleClick = () => {
+    if (hasChildren) {
+      setExpanded((prev) => !prev)
+    }
+    page.onClick?.()
+  }
+
+  return (
+    <li className="list-none mb-1">
+      <button
+        onClick={handleClick}
+        title={isCollapsed ? page.label : undefined}
+        className={`
+          flex items-center w-full text-left transition-colors
+          ${isCollapsed ? 'justify-center px-2' : 'px-3'}
+          ${depth > 0 ? 'py-2' : 'py-3'}
+          rounded-sm
+          ${page.isSelected ? `font-bold ${highlightClass}` : 'font-normal'}
+          text-gray-800 hover:bg-gray-100
+        `}
+        style={
+          page.isSelected
+            ? highlightStyle
+            : undefined
+        }
+        aria-current={page.isSelected ? 'page' : undefined}
+      >
+        {/* Icon */}
+        {IconComponent && (
+          <span className={`shrink-0 ${isCollapsed ? '' : 'mr-3'}`}>
+            <IconComponent className="w-5 h-5 text-gray-700" />
+          </span>
+        )}
+
+        {/* Indentation for children without icons */}
+        {!IconComponent && depth > 0 && !isCollapsed && (
+          <span className="w-5 mr-3 shrink-0" />
+        )}
+
+        {/* Label + badge */}
+        {!isCollapsed && (
+          <span className="flex-1 truncate text-sm text-gray-800">
+            {page.label}
+            {page.badge && (
+              <span className="ml-1 text-gray-500">{page.badge}</span>
+            )}
+          </span>
+        )}
+
+        {/* Group chevron */}
+        {hasChildren && !isCollapsed && (
+          <ChevronRight
+            className={`w-4 h-4 text-gray-400 shrink-0 transition-transform ${
+              expanded ? 'rotate-90' : ''
+            }`}
+          />
+        )}
+      </button>
+
+      {/* Children */}
+      {hasChildren && expanded && !isCollapsed && page.children && (
+        <ul className="list-none m-0 p-0 pl-4" role="group">
+          {page.children.map((child) => (
+            <SiteNavItem
+              key={child.label}
+              page={child}
+              isCollapsed={isCollapsed}
+              highlightClass={highlightClass}
+              highlightStyle={highlightStyle}
+              depth={depth + 1}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}

--- a/src/components/SiteNav/index.ts
+++ b/src/components/SiteNav/index.ts
@@ -1,0 +1,2 @@
+export { SiteNav } from './SiteNav'
+export type { SiteNavProps, SiteNavPage } from './SiteNav'

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -12,7 +12,8 @@ const meta = {
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
   argTypes: {
-    size: { control: 'select', options: ['SMALL', 'STANDARD', 'LARGE'] },
+    variant: { control: 'select', options: ['UNDERLINE', 'PILL'] },
+    size: { control: 'select', options: ['SMALL', 'STANDARD', 'MEDIUM', 'LARGE'] },
     color: { control: 'text' },
     orientation: { control: 'select', options: ['HORIZONTAL', 'VERTICAL'] },
     activationMode: { control: 'select', options: ['AUTOMATIC', 'MANUAL'] },
@@ -259,5 +260,34 @@ export const ManualActivation: Story = {
     ],
     defaultValue: 'manual1',
     activationMode: 'MANUAL',
+  },
+}
+
+
+export const Pill: Story = {
+  args: {
+    tabs: [
+      { value: 'summary', label: 'Summary', content: <p className="text-base text-gray-700">Summary view content.</p> },
+      { value: 'details', label: 'Details', content: <p className="text-base text-gray-700">Details view content.</p> },
+      { value: 'activity', label: 'Activity', content: <p className="text-base text-gray-700">Activity view content.</p> },
+      { value: 'documents', label: 'Documents', content: <p className="text-base text-gray-700">Documents view content.</p> },
+      { value: 'history', label: 'History', content: <p className="text-base text-gray-700">History view content.</p> },
+    ],
+    defaultValue: 'summary',
+    variant: 'PILL',
+    size: 'SMALL',
+  },
+}
+
+export const PillCustomColor: Story = {
+  args: {
+    tabs: [
+      { value: 'tab1', label: 'Tab One', content: <p className="text-base text-gray-700">Custom color pill tab.</p> },
+      { value: 'tab2', label: 'Tab Two', content: <p className="text-base text-gray-700">Custom color pill tab.</p> },
+    ],
+    defaultValue: 'tab1',
+    variant: 'PILL',
+    size: 'SMALL',
+    color: '#9333EA',
   },
 }

--- a/src/components/Tabs/TabsField.tsx
+++ b/src/components/Tabs/TabsField.tsx
@@ -20,6 +20,13 @@ export interface TabItem {
 }
 
 /**
+ * Visual variant for tab styling
+ * - UNDERLINE: Standard tabs with a sliding underline indicator (default)
+ * - PILL: Filled background on active tab with a downward caret indicator
+ */
+export type TabsVariant = "UNDERLINE" | "PILL"
+
+/**
  * Displays a set of layered sections of content (tab panels) that are displayed one at a time
  * Inspired by SAIL form field patterns (not an official SAIL component)
  *
@@ -35,7 +42,9 @@ export interface TabsFieldProps {
   defaultValue?: string
   /** Callback when active tab changes */
   onValueChange?: (value: string) => void
-  /** Orientation of the tabs */
+  /** Visual variant for tab styling */
+  variant?: TabsVariant
+  /** Orientation of the tabs (only applies to UNDERLINE variant) */
   orientation?: "HORIZONTAL" | "VERTICAL"
   /** Size of the tab triggers */
   size?: SAILSize
@@ -60,6 +69,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
   value,
   defaultValue,
   onValueChange,
+  variant = "UNDERLINE",
   orientation = "HORIZONTAL",
   size = "STANDARD",
   loop = true,
@@ -147,13 +157,36 @@ export const TabsField: React.FC<TabsFieldProps> = ({
   }
   const indicatorColor = getIndicatorColor()
 
+  // PILL variant color helpers
+  const getPillBgColor = (): string => {
+    const semanticMap: Record<string, string> = {
+      ACCENT: 'bg-blue-500', POSITIVE: 'bg-green-700', NEGATIVE: 'bg-red-700',
+      SECONDARY: 'bg-gray-700', STANDARD: 'bg-gray-900',
+    }
+    if (semanticMap[color]) return semanticMap[color]
+    if (isPaletteColor(color)) return paletteColorMap[color].bg
+    return '' // hex — handled via inline style
+  }
+  const getPillTextColor = (): string => {
+    const semanticMap: Record<string, string> = {
+      ACCENT: 'text-blue-500', POSITIVE: 'text-green-700', NEGATIVE: 'text-red-700',
+      SECONDARY: 'text-gray-700', STANDARD: 'text-gray-900',
+    }
+    if (semanticMap[color]) return semanticMap[color]
+    if (isPaletteColor(color)) return paletteColorMap[color].text
+    return '' // hex — handled via inline style
+  }
+  const isHexColor = typeof color === 'string' && color.startsWith('#')
+
   // Container classes
   const sailClasses = [marginMap[marginAbove], marginBottomMap[marginBelow]].filter(Boolean).join(' ')
   const containerClasses = mergeClasses(sailClasses, className)
 
-  const listClasses = orientation === "VERTICAL"
-    ? "relative flex flex-col"
-    : "relative flex"
+  const listClasses = variant === "PILL"
+    ? "flex items-end gap-1"
+    : orientation === "VERTICAL"
+      ? "relative flex flex-col"
+      : "relative flex"
 
   const contentClasses = orientation === "VERTICAL" ? "pl-4 flex-1 p-4" : "p-4"
   const rootClasses = orientation === "VERTICAL" ? "flex" : "block"
@@ -173,46 +206,89 @@ export const TabsField: React.FC<TabsFieldProps> = ({
           className={listClasses}
           loop={loop}
         >
-          {tabs.map((tab) => (
-            <Tabs.Trigger
-              key={tab.value}
-              value={tab.value}
-              disabled={tab.disabled}
-              className={[
-                sizeMap[size],
-                'relative bg-white text-gray-700 border-0 cursor-default select-none',
-                'flex items-center justify-center outline-none font-medium',
-                // Horizontal: bottom bar hover + active handled by slider
-                orientation === "HORIZONTAL" && 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:z-10 after:rounded-full after:bg-transparent after:transition-colors after:duration-200 hover:after:bg-gray-500 data-[state=active]:after:bg-transparent',
-                // Vertical: hover background + left bar hover
-                orientation === "VERTICAL" && 'hover:bg-gray-50 after:absolute after:left-0 after:top-0 after:h-full after:w-[2px] after:z-10 after:rounded-full after:bg-transparent after:transition-colors after:duration-200 hover:after:bg-gray-500 data-[state=active]:after:bg-transparent',
-                'data-[state=active]:font-semibold data-[state=active]:text-gray-900',
-                'disabled:opacity-50 disabled:cursor-not-allowed',
-                'focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-blue-500'
-              ].filter(Boolean).join(' ')}
-            >
-              {tab.label}
-            </Tabs.Trigger>
-          ))}
+          {tabs.map((tab) => {
+            if (variant === "PILL") {
+              const isActive = internalActive === tab.value
+              return (
+                <Tabs.Trigger
+                  key={tab.value}
+                  value={tab.value}
+                  disabled={tab.disabled}
+                  className={[
+                    'group relative',
+                    sizeMap[size],
+                    'rounded-sm transition-colors whitespace-nowrap cursor-pointer select-none outline-none border-0',
+                    isActive
+                      ? (!isHexColor ? `${getPillBgColor()} text-white` : '')
+                      : (!isHexColor ? getPillTextColor() : ''),
+                    !isActive ? 'hover:bg-gray-100' : '',
+                    'disabled:opacity-50 disabled:cursor-not-allowed',
+                    'focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2'
+                  ].filter(Boolean).join(' ')}
+                  style={
+                    isHexColor
+                      ? isActive
+                        ? { backgroundColor: color, color: '#ffffff' }
+                        : { color: color }
+                      : undefined
+                  }
+                >
+                  {tab.label}
+                  {isActive && (
+                    <svg
+                      className={[
+                        'absolute left-1/2 -translate-x-1/2 -bottom-1.5 w-3 h-1.5',
+                        !isHexColor ? getPillTextColor() : ''
+                      ].filter(Boolean).join(' ')}
+                      viewBox="0 0 12 6"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="6,6 0,0 12,0"
+                        fill={isHexColor ? color : 'currentColor'}
+                      />
+                    </svg>
+                  )}
+                </Tabs.Trigger>
+              )
+            }
 
-          {/* Full-width base line */}
-          {orientation === "HORIZONTAL" && (
+            return (
+              <Tabs.Trigger
+                key={tab.value}
+                value={tab.value}
+                disabled={tab.disabled}
+                className={[
+                  sizeMap[size],
+                  'relative bg-white text-gray-700 border-0 cursor-default select-none',
+                  'flex items-center justify-center outline-none font-medium',
+                  orientation === "HORIZONTAL" && 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:z-10 after:rounded-full after:bg-transparent after:transition-colors after:duration-200 hover:after:bg-gray-500 data-[state=active]:after:bg-transparent',
+                  orientation === "VERTICAL" && 'hover:bg-gray-50 after:absolute after:left-0 after:top-0 after:h-full after:w-[2px] after:z-10 after:rounded-full after:bg-transparent after:transition-colors after:duration-200 hover:after:bg-gray-500 data-[state=active]:after:bg-transparent',
+                  'data-[state=active]:font-semibold data-[state=active]:text-gray-900',
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
+                  'focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-blue-500'
+                ].filter(Boolean).join(' ')}
+              >
+                {tab.label}
+              </Tabs.Trigger>
+            )
+          })}
+
+          {/* Sliding indicators — UNDERLINE variant only */}
+          {variant === "UNDERLINE" && orientation === "HORIZONTAL" && (
             <span aria-hidden="true" className="absolute bottom-0 left-0 w-full h-[2px] bg-gray-300 pointer-events-none" />
           )}
-          {/* Sliding active segment — horizontal */}
-          {orientation === "HORIZONTAL" && (
+          {variant === "UNDERLINE" && orientation === "HORIZONTAL" && (
             <span
               aria-hidden="true"
               className="absolute bottom-0 h-[2px] rounded-full transition-all duration-300 ease-in-out pointer-events-none z-20"
               style={{ ...indicatorStyle, backgroundColor: indicatorColor }}
             />
           )}
-          {/* Full-height base line — vertical */}
-          {orientation === "VERTICAL" && (
+          {variant === "UNDERLINE" && orientation === "VERTICAL" && (
             <span aria-hidden="true" className="absolute left-0 top-0 h-full w-[2px] bg-gray-300 pointer-events-none" />
           )}
-          {/* Sliding active segment — vertical */}
-          {orientation === "VERTICAL" && (
+          {variant === "UNDERLINE" && orientation === "VERTICAL" && (
             <span
               aria-hidden="true"
               className="absolute left-0 w-[2px] rounded-full transition-all duration-300 ease-in-out pointer-events-none z-20"

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,2 +1,2 @@
 export { TabsField } from './TabsField'
-export type { TabsFieldProps, TabItem } from './TabsField'
+export type { TabsFieldProps, TabItem, TabsVariant } from './TabsField'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -66,3 +66,9 @@ export * from './SideNavAdmin'
 
 // ReadOnlyGrid components
 export * from './ReadOnlyGrid'
+
+// SiteNav component
+export * from './SiteNav'
+
+// RecordView template
+export * from './RecordView'


### PR DESCRIPTION
Rebased port of #60 onto current main (v0.12.1) to avoid merge conflicts with the studio palette overhaul.

**What's included:**

- **SiteNav** — sidebar navigation component with collapsible state, page groups, badges, and user avatar
- **RecordView** — full page template composing SiteNav + record header with action buttons (overflow dropdown for 3+) + pill tabs with per-view content support
- **TabsField PILL variant** — filled background active state with caret indicator, integrated with the new palette color system (`isPaletteColor`, `paletteColorMap`) and `mergeClasses`. Sliding indicator only renders for UNDERLINE variant.
- **@radix-ui/react-dropdown-menu** dependency for the overflow action menu
- Stories for all new components and variants


<img width="1727" height="961" alt="image" src="https://github.com/user-attachments/assets/7719eaeb-98c9-4da8-8277-e02dc9a96996" />
