### PR TITLE
feat: centralize SAIL enum → Tailwind class mappings

### DIFF
--- a/.kiro/specs/centralize-sail-maps/design.md
+++ b/.kiro/specs/centralize-sail-maps/design.md
@@ -1,0 +1,129 @@
+# Design: Centralize SAIL Enum → Tailwind Class Mappings
+
+## Approach
+
+### Phase 1: Create Shared Module + Refactor Components
+1. Create `src/utils/sailMaps.ts` with all canonical maps
+2. Update each component to import from the shared module
+3. Remove inline map definitions
+4. Standardize naming (TabsField)
+5. Verify no visual changes via build + tests
+
+### Phase 2: Token-Driven Generation (Stretch)
+1. Extend `tokens.json` with SAIL enum metadata if needed
+2. Create or extend a generation script to produce `sailMaps.ts` from tokens
+3. Wire into `pnpm run build:tokens` pipeline
+
+## Shared Module Design
+
+```typescript
+// src/utils/sailMaps.ts
+import type { SAILMarginSize, SAILPadding, SAILShape, SAILSize, SAILSizeExtended, SAILAlign } from '../types/sail'
+
+// --- Margin Maps ---
+export const marginAboveMap: Record<SAILMarginSize, string> = {
+  NONE: '',
+  EVEN_LESS: 'mt-1',
+  LESS: 'mt-2',
+  STANDARD: 'mt-4',
+  MORE: 'mt-6',
+  EVEN_MORE: 'mt-8'
+}
+
+export const marginBelowMap: Record<SAILMarginSize, string> = {
+  NONE: '',
+  EVEN_LESS: 'mb-1',
+  LESS: 'mb-2',
+  STANDARD: 'mb-4',
+  MORE: 'mb-6',
+  EVEN_MORE: 'mb-8'
+}
+
+// --- Padding Map ---
+export const paddingMap: Record<SAILPadding, string> = {
+  NONE: 'p-0',
+  EVEN_LESS: 'p-1',
+  LESS: 'p-2',
+  STANDARD: 'p-4',
+  MORE: 'p-6',
+  EVEN_MORE: 'p-8'
+}
+
+// --- Shape Map ---
+export const shapeMap: Record<SAILShape, string> = {
+  SQUARED: 'rounded-none',
+  SEMI_ROUNDED: 'rounded-sm',
+  ROUNDED: 'rounded-md'
+}
+
+// --- Button/Interactive Size Maps ---
+export const buttonSizeMap: Record<SAILSize, string> = {
+  SMALL: 'px-3 py-2 text-sm leading-none',
+  STANDARD: 'px-4 py-3 text-base leading-none',
+  MEDIUM: 'px-5 py-4 text-lg leading-none',
+  LARGE: 'px-6 py-5 text-xl leading-none'
+}
+
+export const buttonIconOnlySizeMap: Record<SAILSize, string> = {
+  SMALL: 'p-2 text-sm',
+  STANDARD: 'p-3 text-base',
+  MEDIUM: 'p-4 text-lg',
+  LARGE: 'p-5 text-xl'
+}
+
+// --- Text Size Map ---
+export const textSizeMap: Record<SAILSizeExtended, string> = {
+  SMALL: 'text-xs',
+  STANDARD: 'text-base',
+  MEDIUM: 'text-lg',
+  MEDIUM_PLUS: 'text-xl',
+  LARGE: 'text-2xl',
+  LARGE_PLUS: 'text-3xl',
+  EXTRA_LARGE: 'text-4xl'
+}
+
+// --- Alignment Map ---
+export const alignMap: Record<SAILAlign, string> = {
+  START: 'justify-start',
+  CENTER: 'justify-center',
+  END: 'justify-end'
+}
+```
+
+## Component Refactor Pattern
+
+Before:
+```typescript
+// Inside component function
+const marginAboveMap: Record<SAILMarginSize, string> = {
+  NONE: '', EVEN_LESS: 'mt-1', LESS: 'mt-2', STANDARD: 'mt-4', MORE: 'mt-6', EVEN_MORE: 'mt-8'
+}
+```
+
+After:
+```typescript
+// At top of file
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
+// No local definition needed — use imported maps directly
+```
+
+## Risk Mitigation
+
+### Visual Regression
+- Run `pnpm build` before and after to catch TypeScript errors
+- Run `pnpm test` before and after to catch behavioral regressions
+- Manually verify Storybook for each affected component category (buttons, cards, text, stamps, etc.)
+- This is a pure refactor — no logic changes, no value changes
+
+### Incremental Approach
+- Can be done component-by-component if needed
+- Each component update is independently verifiable
+- FieldWrapper is the highest-impact single change (used by ~10 form components)
+
+## Files Changed
+
+### Created
+- `src/utils/sailMaps.ts`
+
+### Modified (15 components)
+- FieldWrapper, CardLayout, HeadingField, ButtonWidget, ButtonArrayLayout, TagField, MessageBanner, StampField, RichTextDisplayField, DialogField, ProgressBar, MilestoneField, TabsField, ToggleField, SiteNav

--- a/.kiro/specs/centralize-sail-maps/requirements.md
+++ b/.kiro/specs/centralize-sail-maps/requirements.md
@@ -1,0 +1,83 @@
+# Requirements: Centralize SAIL Enum → Tailwind Class Mappings
+
+GitHub Issue: [#83](https://github.com/pglevy/sailwind/issues/83)
+
+## Big Picture Vision
+
+Sailwind mostly uses existing Tailwind classes to express the Appian SAIL design system, but in the language of SAIL (STANDARD, MORE, EVEN_MORE). Everything is driven from `tokens.json` as the source of truth. The goal is to make it easy to get the Appian look and feel by default, while not limiting designers — they can customize prototypes using Tailwind classes via `className`. LLMs will frequently use Tailwind classes by default, so those need to work too.
+
+## Problem
+
+Each component independently maps SAIL enums (SAILSize, SAILMarginSize, SAILShape, SAILPadding) to Tailwind classes. These maps are hand-rolled and duplicated across 11+ components with no guarantee of consistency or alignment with `tokens.json`.
+
+## Current State (Audit)
+
+### Duplicated Maps
+
+| Map Type | Components | Identical? |
+|----------|-----------|-----------|
+| marginAboveMap | FieldWrapper, CardLayout, HeadingField, ButtonArrayLayout, TagField, MessageBanner, StampField, RichTextDisplayField, DialogField, ProgressBar, MilestoneField, TabsField | Yes (TabsField uses different variable names) |
+| marginBelowMap | Same 12 components | Yes |
+| shapeMap | CardLayout, MessageBanner, StampField | Yes |
+| buttonSizeMap | ButtonWidget, TabsField, ToggleField | Yes |
+| paddingMap | CardLayout only | N/A (single source) |
+
+### Component-Specific Maps (Keep Local)
+- StampField — complex `{ container, text, icon }` structure
+- ImageField — standard + avatar size variants
+- SwitchField — size, label, gap maps
+- SliderField — complex track/thumb structure
+- HeadingField — extended size scale (EXTRA_SMALL through LARGE_PLUS)
+- Icon — numeric pixel sizes
+
+### Existing Shared Infrastructure
+- `src/utils/colorResolver.ts` — semantic + palette color resolution (already centralized)
+- `src/utils/classNames.ts` — class merging utility
+- `src/types/palette-colors.generated.ts` — auto-generated from tokens.json
+- `scripts/generate-palette-types.ts` — generation pipeline
+
+## Requirements
+
+### REQ-1: Shared Mapping Module
+Create `src/utils/sailMaps.ts` exporting canonical SAIL enum → Tailwind class maps:
+- `marginAboveMap: Record<SAILMarginSize, string>`
+- `marginBelowMap: Record<SAILMarginSize, string>`
+- `paddingMap: Record<SAILPadding, string>`
+- `shapeMap: Record<SAILShape, string>`
+- `buttonSizeMap: Record<SAILSize, string>`
+- `buttonIconOnlySizeMap: Record<SAILSize, string>`
+- `alignMap: Record<SAILAlign, string>`
+- `textSizeMap: Record<SAILSizeExtended, string>`
+
+### REQ-2: Refactor Components
+All 15 components with duplicated maps must import from the shared module instead of defining their own. No visual changes should result.
+
+Components to update:
+1. src/components/shared/FieldWrapper.tsx
+2. src/components/Card/CardLayout.tsx
+3. src/components/Heading/HeadingField.tsx
+4. src/components/Button/ButtonWidget.tsx
+5. src/components/Button/ButtonArrayLayout.tsx
+6. src/components/Tag/TagField.tsx
+7. src/components/MessageBanner/MessageBanner.tsx
+8. src/components/Stamp/StampField.tsx
+9. src/components/RichText/RichTextDisplayField.tsx
+10. src/components/Dialog/DialogField.tsx
+11. src/components/ProgressBar/ProgressBar.tsx
+12. src/components/Milestone/MilestoneField.tsx
+13. src/components/Tabs/TabsField.tsx (also standardize variable naming)
+14. src/components/Toggle/ToggleField.tsx
+15. src/components/SiteNav/SiteNav.tsx (if applicable)
+
+### REQ-3: Token-Driven Generation (Stretch)
+Ideally generate `sailMaps.ts` from `tokens.json` via the existing pipeline (`scripts/generate-tokens.ts` or a new script), so token changes automatically produce correct Tailwind mappings. Follow the same pattern as `generate-palette-types.ts`.
+
+### REQ-4: Visual Regression Safety
+No visual changes should result from this refactor. Before/after Storybook screenshots should be identical. Consider:
+- Running existing tests before and after
+- Storybook visual comparison for affected components
+- Build verification (`pnpm build`)
+
+### REQ-5: Naming Standardization
+Standardize map variable names across all components:
+- TabsField currently uses `marginMap` / `marginBottomMap` — should align with `marginAboveMap` / `marginBelowMap` convention

--- a/.kiro/specs/centralize-sail-maps/tasks.md
+++ b/.kiro/specs/centralize-sail-maps/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Centralize SAIL Enum → Tailwind Class Mappings
+
+## Phase 1: Create Shared Module + Refactor
+
+- [ ] Task 1: Create `src/utils/sailMaps.ts` with all canonical maps (marginAboveMap, marginBelowMap, paddingMap, shapeMap, buttonSizeMap, buttonIconOnlySizeMap, textSizeMap, alignMap)
+- [ ] Task 2: Refactor FieldWrapper to import from sailMaps (highest impact — used by ~10 form components)
+- [ ] Task 3: Refactor CardLayout to import margin, padding, and shape maps from sailMaps
+- [ ] Task 4: Refactor HeadingField to import margin maps from sailMaps
+- [ ] Task 5: Refactor ButtonWidget to import buttonSizeMap and buttonIconOnlySizeMap from sailMaps
+- [ ] Task 6: Refactor ButtonArrayLayout to import margin maps from sailMaps
+- [ ] Task 7: Refactor TagField to import margin maps from sailMaps
+- [ ] Task 8: Refactor MessageBanner to import margin and shape maps from sailMaps
+- [ ] Task 9: Refactor StampField to import margin and shape maps from sailMaps (keep component-specific sizeMap local)
+- [ ] Task 10: Refactor RichTextDisplayField to import margin maps from sailMaps
+- [ ] Task 11: Refactor DialogField to import margin maps from sailMaps
+- [ ] Task 12: Refactor ProgressBar to import margin maps from sailMaps
+- [ ] Task 13: Refactor MilestoneField to import margin maps from sailMaps
+- [ ] Task 14: Refactor TabsField to import margin and buttonSize maps from sailMaps, standardize variable naming (marginMap → marginAboveMap, marginBottomMap → marginBelowMap)
+- [ ] Task 15: Refactor ToggleField to import buttonSizeMap from sailMaps
+- [ ] Task 16: Run build verification (`pnpm build`) and tests (`pnpm test`) to confirm no regressions
+- [ ] Task 17: Verify Storybook renders correctly for all affected components
+
+## Phase 2: Token-Driven Generation (Stretch)
+
+- [ ] Task 18: Investigate extending `tokens.json` with SAIL enum → Tailwind mapping metadata
+- [ ] Task 19: Create or extend generation script to produce `sailMaps.ts` from tokens
+- [ ] Task 20: Wire generation into `pnpm run build:tokens` pipeline

--- a/src/components/Button/ButtonArrayLayout.tsx
+++ b/src/components/Button/ButtonArrayLayout.tsx
@@ -3,6 +3,7 @@ import type { ButtonWidgetProps } from './ButtonWidget'
 import { ButtonWidget } from './ButtonWidget'
 import type { SAILAlign, SAILMarginSize } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
+import { marginBelowMap, alignMap } from '../../utils/sailMaps'
 
 /**
  * Props for the ButtonArrayLayout component
@@ -44,23 +45,6 @@ export const ButtonArrayLayout: React.FC<ButtonArrayLayoutProps> = ({
 
   // Filter out hidden buttons
   const visibleButtons = buttons.filter(btn => btn.showWhen !== false)
-
-  // Alignment mappings
-  const alignMap: Record<SAILAlign, string> = {
-    START: 'justify-start',
-    CENTER: 'justify-center',
-    END: 'justify-end'
-  }
-
-  // Margin mappings - using Tailwind standard classes that map to SAIL values
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',           // SAIL NONE: no class needed
-    EVEN_LESS: 'mb-1', // SAIL EVEN_LESS: 4px
-    LESS: 'mb-2',      // SAIL LESS: 8px
-    STANDARD: 'mb-4',  // SAIL STANDARD: 16px
-    MORE: 'mb-6',      // SAIL MORE: 24px
-    EVEN_MORE: 'mb-8'  // SAIL EVEN_MORE: 32px
-  }
 
   // SAIL behavior: single button renders right-justified, multiple buttons left-justified
   const defaultAlign = visibleButtons.length === 1 ? 'END' : 'START'

--- a/src/components/Button/ButtonWidget.tsx
+++ b/src/components/Button/ButtonWidget.tsx
@@ -3,6 +3,7 @@ import * as LucideIcons from 'lucide-react'
 import type { SAILSize, SAILColorInput } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
 import { resolveColorClass, isSemanticColor, isPaletteColor } from '../../utils/colorResolver'
+import { buttonSizeMap, buttonIconOnlySizeMap } from '../../utils/sailMaps'
 
 type ButtonStyle = "SOLID" | "OUTLINE" | "GHOST" | "LINK"
 type ButtonWidth = "MINIMIZE" | "FILL"
@@ -91,24 +92,8 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   // Visibility control
   if (!showWhen) return null
 
-  // Size mappings - leading-none removes line-height so button height is purely padding-driven
-  const sizeMap: Record<SAILSize, string> = {
-    SMALL: 'px-3 py-2 text-sm leading-none',
-    STANDARD: 'px-4 py-3 text-base leading-none',
-    MEDIUM: 'px-5 py-4 text-lg leading-none',
-    LARGE: 'px-6 py-5 text-xl leading-none'
-  }
-
-  // Icon-only size mappings — uniform padding for square aspect ratio
-  const iconOnlySizeMap: Record<SAILSize, string> = {
-    SMALL: 'p-2 text-sm',
-    STANDARD: 'p-3 text-base',
-    MEDIUM: 'p-4 text-lg',
-    LARGE: 'p-5 text-xl'
-  }
-
   const isIconOnly = !!icon && !label
-  const effectiveSizeClasses = isIconOnly ? iconOnlySizeMap[size] : sizeMap[size]
+  const effectiveSizeClasses = isIconOnly ? buttonIconOnlySizeMap[size] : buttonSizeMap[size]
 
   // Width mappings
   const widthClass = width === "FILL" ? 'w-full' : 'w-auto'

--- a/src/components/Card/CardLayout.tsx
+++ b/src/components/Card/CardLayout.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import type { SAILShape, SAILPadding, SAILMarginSize, SAILColorInput } from '../../types/sail'
 import { isPaletteColor, resolveColorClass } from '../../utils/colorResolver'
 import { mergeClasses } from '../../utils/classNames'
+import { marginAboveMap, marginBelowMap, paddingMap, shapeMap } from '../../utils/sailMaps'
 
 type CardHeight = "AUTO" | "SHORT" | "MEDIUM" | "TALL" | "EXTRA_TALL"
 type CardStyle = "NONE" | "TRANSPARENT" | "STANDARD" | "ACCENT" | "SUCCESS" | "WARN" | "ERROR" | "INFO" | "CHARCOAL_SCHEME" | "NAVY_SCHEME" | "PLUM_SCHEME"
@@ -72,42 +73,6 @@ export const CardLayout: React.FC<CardLayoutProps> = ({
     MEDIUM: 'h-48',
     TALL: 'h-64',
     EXTRA_TALL: 'h-96'
-  }
-
-  // Shape mappings - using Tailwind standard classes that map to SAIL values
-  const shapeMap: Record<SAILShape, string> = {
-    SQUARED: 'rounded-none',  // SAIL SQUARED: 0
-    SEMI_ROUNDED: 'rounded-sm', // SAIL SEMI_ROUNDED: 4px
-    ROUNDED: 'rounded-md'     // SAIL ROUNDED: 8px
-  }
-
-  // Padding mappings - using Tailwind standard classes that map to SAIL values
-  const paddingMap: Record<SAILPadding, string> = {
-    NONE: 'p-0',      // SAIL NONE: 0
-    EVEN_LESS: 'p-1', // SAIL EVEN_LESS: 4px
-    LESS: 'p-2',      // SAIL LESS: 8px
-    STANDARD: 'p-4',  // SAIL STANDARD: 16px
-    MORE: 'p-6',      // SAIL MORE: 24px
-    EVEN_MORE: 'p-8'  // SAIL EVEN_MORE: 32px
-  }
-
-  // Margin mappings - using Tailwind standard classes that map to SAIL values
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',           // SAIL NONE: no class needed
-    EVEN_LESS: 'mt-1', // SAIL EVEN_LESS: 4px
-    LESS: 'mt-2',      // SAIL LESS: 8px
-    STANDARD: 'mt-4',  // SAIL STANDARD: 16px
-    MORE: 'mt-6',      // SAIL MORE: 24px
-    EVEN_MORE: 'mt-8'  // SAIL EVEN_MORE: 32px
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',           // SAIL NONE: no class needed
-    EVEN_LESS: 'mb-1', // SAIL EVEN_LESS: 4px
-    LESS: 'mb-2',      // SAIL LESS: 8px
-    STANDARD: 'mb-4',  // SAIL STANDARD: 16px
-    MORE: 'mb-6',      // SAIL MORE: 24px
-    EVEN_MORE: 'mb-8'  // SAIL EVEN_MORE: 32px
   }
 
   // Background color mappings for card styles

--- a/src/components/Checkbox/CheckboxField.tsx
+++ b/src/components/Checkbox/CheckboxField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { FieldWrapper } from '../shared/FieldWrapper'
-import type { SAILLabelPosition, SAILMarginSize, SAILAlign } from '../../types/sail'
+import type { SAILLabelPosition, SAILMarginSize, SAILAlignLegacy } from '../../types/sail'
+import { legacyAlignMap } from '../../utils/sailMaps'
 
 type ChoiceLayout = "STACKED" | "COMPACT"
 type ChoiceStyle = "STANDARD" | "CARDS"
@@ -37,7 +38,7 @@ export interface CheckboxFieldProps {
   /** Custom message when field is required and not provided */
   requiredMessage?: string
   /** Determines alignment of choice labels. Use with Grid Layout */
-  align?: SAILAlign | "LEFT" | "CENTER" | "RIGHT"
+  align?: SAILAlignLegacy
   /** Determines where the label appears */
   labelPosition?: SAILLabelPosition
   /** Displays a help icon with tooltip text */
@@ -115,15 +116,6 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
     EVEN_MORE: 'gap-6'
   }
 
-  // Map align parameter to Tailwind classes
-  const alignMap: Record<string, string> = {
-    LEFT: 'justify-start',
-    START: 'justify-start',
-    CENTER: 'justify-center',
-    RIGHT: 'justify-end',
-    END: 'justify-end'
-  }
-
   const handleChange = (choiceValue: any, checked: boolean) => {
     const handler = onChange || saveInto
     if (!handler) return
@@ -147,7 +139,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
       className={[
         choiceLayout === "STACKED" ? 'flex flex-col' : 'flex flex-wrap',
         spacingMap[spacing],
-        align && alignMap[align]
+        align && legacyAlignMap[align]
       ].filter(Boolean).join(' ')}
       role="group"
       aria-describedby={instructions ? `${inputId}-instructions` : undefined}

--- a/src/components/Dialog/DialogField.tsx
+++ b/src/components/Dialog/DialogField.tsx
@@ -3,6 +3,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
 import type { SAILMarginSize } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 /**
  * Width options for dialog sizing
@@ -77,25 +78,6 @@ export const DialogField: React.FC<DialogFieldProps> = ({
   // Visibility control
   if (!showWhen) return null
 
-  // Margin mappings
-  const marginMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBottomMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
-
   // Width mappings
   const widthMap: Record<DialogWidth, string> = {
     NARROW: 'w-[90vw] max-w-sm',      // ~384px max
@@ -117,8 +99,8 @@ export const DialogField: React.FC<DialogFieldProps> = ({
 
   // Container classes
   const sailClasses = [
-    marginMap[marginAbove],
-    marginBottomMap[marginBelow]
+    marginAboveMap[marginAbove],
+    marginBelowMap[marginBelow]
   ].filter(Boolean).join(' ')
 
   const containerClasses = mergeClasses(sailClasses, className)

--- a/src/components/Heading/HeadingField.tsx
+++ b/src/components/Heading/HeadingField.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import type { SAILAlign, SAILMarginSize, SAILColorInput } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
 import { resolveColorClass, isSemanticColor, isPaletteColor } from '../../utils/colorResolver'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 /**
  * Heading size values matching SAIL's size parameter
@@ -92,25 +93,6 @@ export const HeadingField: React.FC<HeadingFieldProps> = ({
     START: 'text-left',
     CENTER: 'text-center',
     END: 'text-right'
-  }
-
-  // Margin mappings
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
   }
 
   // Build color styles — semantic, palette, or hex

--- a/src/components/Heading/HeadingField.tsx
+++ b/src/components/Heading/HeadingField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import type { SAILAlign, SAILMarginSize, SAILColorInput } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
 import { resolveColorClass, isSemanticColor, isPaletteColor } from '../../utils/colorResolver'
-import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
+import { marginAboveMap, marginBelowMap, textAlignMap } from '../../utils/sailMaps'
 
 /**
  * Heading size values matching SAIL's size parameter
@@ -88,13 +88,6 @@ export const HeadingField: React.FC<HeadingFieldProps> = ({
     BOLD: 'font-bold'            // 700
   }
 
-  // Alignment mappings
-  const alignMap: Record<SAILAlign, string> = {
-    START: 'text-left',
-    CENTER: 'text-center',
-    END: 'text-right'
-  }
-
   // Build color styles — semantic, palette, or hex
   const colorStyles = isSemanticColor(color)
     ? { className: resolveColorClass(color, 'text') }
@@ -128,7 +121,7 @@ export const HeadingField: React.FC<HeadingFieldProps> = ({
   const sailClasses = [
     sizeMap[size],
     fontWeightMap[fontWeight],
-    alignMap[align],
+    textAlignMap[align],
     marginAboveMap[marginAbove],
     marginBelowMap[marginBelow],
     preventWrapping && 'truncate',

--- a/src/components/Image/ImageField.tsx
+++ b/src/components/Image/ImageField.tsx
@@ -4,6 +4,7 @@ import { FieldWrapper } from '../shared/FieldWrapper'
 import type { SAILLabelPosition, SAILMarginSize, SAILAlign } from '../../types/sail'
 import type { DocumentImageProps } from './DocumentImage'
 import type { UserImageProps } from './UserImage'
+import { alignMap } from '../../utils/sailMaps'
 
 // Union type for all image types supported by ImageField
 type ImageFieldImage = DocumentImageProps | UserImageProps
@@ -118,13 +119,6 @@ export const ImageField: React.FC<ImageFieldProps> = ({
     EXTRA_LARGE: 'w-96 h-96', // 384x384px (same as LARGE)
     GALLERY: 'w-20 h-20', // 80x80px (square version of gallery)
     FIT: 'max-w-full h-auto aspect-square' // Natural dimensions, square
-  }
-
-  // Map SAIL align values to Tailwind classes
-  const alignMap: Record<SAILAlign, string> = {
-    START: 'justify-start',
-    CENTER: 'justify-center',
-    END: 'justify-end'
   }
 
   // Style-specific classes

--- a/src/components/MessageBanner/MessageBanner.tsx
+++ b/src/components/MessageBanner/MessageBanner.tsx
@@ -4,6 +4,7 @@ import type { SAILShape, SAILMarginSize, SAILAlign } from '../../types/sail'
 import type { ButtonWidgetProps } from '../Button/ButtonWidget'
 import { ButtonArrayLayout } from '../Button/ButtonArrayLayout'
 import { mergeClasses } from '../../utils/classNames'
+import { marginAboveMap, marginBelowMap, shapeMap } from '../../utils/sailMaps'
 
 export type BackgroundColor = "INFO" | "SUCCESS" | "WARN" | "ERROR" | string
 export type HighlightColor = "INFO" | "POSITIVE" | "WARN" | "NEGATIVE" | string
@@ -70,31 +71,6 @@ export const MessageBanner: React.FC<MessageBannerProps> = ({
 
   // Don't render visually if announce-only
   const isVisuallyHidden = announceBehavior === "ANNOUNCE_ONLY"
-
-  // Styling maps using standard Tailwind classes
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
-
-  const shapeMap: Record<SAILShape, string> = {
-    SQUARED: 'rounded-none',
-    SEMI_ROUNDED: 'rounded-sm',
-    ROUNDED: 'rounded-md'
-  }
 
   // Semantic color mappings with dark semantic text
   const backgroundColorMap: Record<string, { bg: string; text: string }> = {

--- a/src/components/Milestone/MilestoneField.tsx
+++ b/src/components/Milestone/MilestoneField.tsx
@@ -3,6 +3,7 @@ import { FieldLabel } from '../shared/FieldLabel'
 import type { SAILLabelPosition, SAILMarginSize, SAILColorInput } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
 import { isPaletteColor, resolveColorClass } from '../../utils/colorResolver'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 type Orientation = "HORIZONTAL" | "VERTICAL"
 type StepStyle = "LINE" | "CHEVRON" | "DOT"
@@ -66,25 +67,6 @@ export const MilestoneField: React.FC<MilestoneFieldProps> = ({
   if (!showWhen) return null
 
   const fieldId = `milestone-${Math.random().toString(36).slice(2, 11)}`
-
-  // Map SAIL margin values to Tailwind classes
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
 
   // Map semantic colors to Tailwind classes
   const getColorClasses = (colorValue: Color) => {

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -4,6 +4,7 @@ import type { SAILLabelPosition, SAILMarginSize, SAILColorInput } from '../../ty
 import { isPaletteColor, resolveColorClass } from '../../utils/colorResolver'
 import { FieldLabel } from '../shared/FieldLabel'
 import { mergeClasses } from '../../utils/classNames'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 export type ProgressBarColor = "ACCENT" | "POSITIVE" | "NEGATIVE" | "WARN" | SAILColorInput
 export type ProgressBarStyle = "THIN" | "THICK"
@@ -61,25 +62,6 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
 
   // Generate unique ID for accessibility
   const progressId = React.useId()
-
-  // Styling maps using standard Tailwind classes
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
 
   const styleMap: Record<ProgressBarStyle, { height: string; textSize: string }> = {
     THIN: { height: 'h-2', textSize: 'text-sm' },

--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, MoveUp, MoveDow
 import { isPaletteColor, resolveColorClass } from '../../utils/colorResolver'
 import { FieldWrapper } from "../shared/FieldWrapper";
 import { GridColumn, type GridColumnProps } from "./GridColumn";
+import { textAlignMap } from "../../utils/sailMaps";
 import type {
   SAILLabelPosition,
   SAILMarginSize,
@@ -148,12 +149,6 @@ const widthMap: Record<string, string> = {
   "8X": "flex-[8]",
   "9X": "flex-[9]",
   "10X": "flex-[10]",
-};
-
-const alignMap: Record<string, string> = {
-  START: "text-left",
-  CENTER: "text-center",
-  END: "text-right",
 };
 
 const bgColorMap: Record<string, string> = {
@@ -342,7 +337,7 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
     col.width && widthMap[col.width] ? widthMap[col.width] : "";
 
   const getColAlignClass = (col: GridColumnProps) =>
-    col.align && alignMap[col.align] ? alignMap[col.align] : "text-left";
+    col.align && textAlignMap[col.align] ? textAlignMap[col.align] : "text-left";
 
   const renderTable = () => (
     <table

--- a/src/components/RichText/RichTextDisplayField.tsx
+++ b/src/components/RichText/RichTextDisplayField.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { FieldLabel } from '../shared/FieldLabel'
 import type { SAILLabelPosition, SAILMarginSize } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 type TextAlign = "LEFT" | "CENTER" | "RIGHT"
 
@@ -54,25 +55,6 @@ export const RichTextDisplayField: React.FC<RichTextDisplayFieldProps> = ({
   className: classNameProp
 }) => {
   if (!showWhen) return null
-
-  // Margin mappings
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
 
   // Alignment mappings
   const alignMap: Record<TextAlign, string> = {

--- a/src/components/RichText/RichTextDisplayField.tsx
+++ b/src/components/RichText/RichTextDisplayField.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { FieldLabel } from '../shared/FieldLabel'
-import type { SAILLabelPosition, SAILMarginSize } from '../../types/sail'
+import type { SAILLabelPosition, SAILMarginSize, SAILAlignLegacy } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
-import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
+import { marginAboveMap, marginBelowMap, legacyTextAlignMap } from '../../utils/sailMaps'
 
-type TextAlign = "LEFT" | "CENTER" | "RIGHT"
+type TextAlign = SAILAlignLegacy
 
 export interface RichTextDisplayFieldProps {
   /** Text to display as the field label */
@@ -56,13 +56,6 @@ export const RichTextDisplayField: React.FC<RichTextDisplayFieldProps> = ({
 }) => {
   if (!showWhen) return null
 
-  // Alignment mappings
-  const alignMap: Record<TextAlign, string> = {
-    LEFT: 'text-left',
-    CENTER: 'text-center',
-    RIGHT: 'text-right'
-  }
-
   // Build container classes
   const sailClasses = [
     marginAboveMap[marginAbove],
@@ -73,7 +66,7 @@ export const RichTextDisplayField: React.FC<RichTextDisplayFieldProps> = ({
 
   // Build content classes
   const contentClasses = [
-    alignMap[align],
+    legacyTextAlignMap[align],
     preventWrapping && 'truncate',
     'leading-relaxed' // Better line spacing for rich text
   ].filter(Boolean).join(' ')

--- a/src/components/Stamp/StampField.tsx
+++ b/src/components/Stamp/StampField.tsx
@@ -3,7 +3,7 @@ import * as LucideIcons from 'lucide-react'
 import type { SAILLabelPosition, SAILMarginSize, SAILAlign, SAILShape, SAILColorInput } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
 import { resolveColorClass, isSemanticColor, isPaletteColor } from '../../utils/colorResolver'
-import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
+import { marginAboveMap, marginBelowMap, alignMap } from '../../utils/sailMaps'
 
 type StampSize = "TINY" | "SMALL" | "MEDIUM" | "LARGE"
 type StampBackgroundColor = SAILColorInput | "TRANSPARENT"
@@ -80,12 +80,6 @@ export const StampField: React.FC<StampFieldProps> = ({
     SMALL: { container: 'w-8 h-8', text: 'text-sm', icon: 'text-sm' },
     MEDIUM: { container: 'w-12 h-12', text: 'text-base', icon: 'text-base' },
     LARGE: { container: 'w-16 h-16', text: 'text-lg', icon: 'text-lg' }
-  }
-
-  const alignMap: Record<SAILAlign, string> = {
-    START: 'justify-start',
-    CENTER: 'justify-center',
-    END: 'justify-end'
   }
 
   const shapeMap: Record<SAILShape, string> = {

--- a/src/components/Stamp/StampField.tsx
+++ b/src/components/Stamp/StampField.tsx
@@ -3,6 +3,7 @@ import * as LucideIcons from 'lucide-react'
 import type { SAILLabelPosition, SAILMarginSize, SAILAlign, SAILShape, SAILColorInput } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
 import { resolveColorClass, isSemanticColor, isPaletteColor } from '../../utils/colorResolver'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 type StampSize = "TINY" | "SMALL" | "MEDIUM" | "LARGE"
 type StampBackgroundColor = SAILColorInput | "TRANSPARENT"
@@ -73,25 +74,6 @@ export const StampField: React.FC<StampFieldProps> = ({
 }) => {
   // Visibility control
   if (!showWhen) return null
-
-  // Styling maps using standard Tailwind classes
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
 
   const sizeMap: Record<StampSize, { container: string; text: string; icon: string }> = {
     TINY: { container: 'w-6 h-6', text: 'text-xs', icon: 'text-xs' },

--- a/src/components/Tabs/TabsField.tsx
+++ b/src/components/Tabs/TabsField.tsx
@@ -4,6 +4,7 @@ import type { SAILMarginSize, SAILSize, SAILColorInput } from '../../types/sail'
 import { isPaletteColor } from '../../utils/colorResolver'
 import { paletteColorMap } from '../../types/palette-colors.generated'
 import { mergeClasses } from '../../utils/classNames'
+import { marginAboveMap, marginBelowMap, buttonSizeMap } from '../../utils/sailMaps'
 
 /**
  * Individual tab configuration
@@ -112,33 +113,6 @@ export const TabsField: React.FC<TabsFieldProps> = ({
   // Visibility control
   if (!showWhen) return null
 
-  // Margin mappings
-  const marginMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBottomMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
-
-  // Size mappings for tab triggers — matches ButtonWidget
-  const sizeMap: Record<SAILSize, string> = {
-    SMALL: 'px-3 py-2 text-sm leading-none',
-    STANDARD: 'px-4 py-3 text-base leading-none',
-    MEDIUM: 'px-5 py-4 text-lg leading-none',
-    LARGE: 'px-6 py-5 text-xl leading-none'
-  }
-
   // Active indicator color
   const getIndicatorColor = (): string => {
     const semanticMap: Record<string, string> = {
@@ -179,7 +153,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
   const isHexColor = typeof color === 'string' && color.startsWith('#')
 
   // Container classes
-  const sailClasses = [marginMap[marginAbove], marginBottomMap[marginBelow]].filter(Boolean).join(' ')
+  const sailClasses = [marginAboveMap[marginAbove], marginBelowMap[marginBelow]].filter(Boolean).join(' ')
   const containerClasses = mergeClasses(sailClasses, className)
 
   const listClasses = variant === "PILL"
@@ -216,7 +190,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
                   disabled={tab.disabled}
                   className={[
                     'group relative',
-                    sizeMap[size],
+                    buttonSizeMap[size],
                     'rounded-sm transition-colors whitespace-nowrap cursor-pointer select-none outline-none border-0',
                     isActive
                       ? (!isHexColor ? `${getPillBgColor()} text-white` : '')
@@ -259,7 +233,7 @@ export const TabsField: React.FC<TabsFieldProps> = ({
                 value={tab.value}
                 disabled={tab.disabled}
                 className={[
-                  sizeMap[size],
+                  buttonSizeMap[size],
                   'relative bg-white text-gray-700 border-0 cursor-default select-none',
                   'flex items-center justify-center outline-none font-medium',
                   orientation === "HORIZONTAL" && 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:z-10 after:rounded-full after:bg-transparent after:transition-colors after:duration-200 hover:after:bg-gray-500 data-[state=active]:after:bg-transparent',

--- a/src/components/Tag/TagField.tsx
+++ b/src/components/Tag/TagField.tsx
@@ -4,6 +4,7 @@ import type { SAILSize, SAILAlign, SAILLabelPosition, SAILMarginSize } from '../
 import { FieldLabel } from '../shared/FieldLabel'
 import { mergeClasses } from '../../utils/classNames'
 import { resolveColorClass, isSemanticColor, isPaletteColor } from '../../utils/colorResolver'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 /**
  * Tag size - only SMALL and STANDARD are supported per SAIL docs
@@ -76,25 +77,6 @@ export const TagField: React.FC<TagFieldProps> = ({
     START: 'justify-start',
     CENTER: 'justify-center',
     END: 'justify-end'
-  }
-
-  // Margin mappings - using Tailwind standard classes that map to SAIL values
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',           // SAIL NONE: no class needed
-    EVEN_LESS: 'mt-1', // SAIL EVEN_LESS: 4px
-    LESS: 'mt-2',      // SAIL LESS: 8px
-    STANDARD: 'mt-4',  // SAIL STANDARD: 16px
-    MORE: 'mt-6',      // SAIL MORE: 24px
-    EVEN_MORE: 'mt-8'  // SAIL EVEN_MORE: 32px
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',           // SAIL NONE: no class needed
-    EVEN_LESS: 'mb-1', // SAIL EVEN_LESS: 4px
-    LESS: 'mb-2',      // SAIL LESS: 8px
-    STANDARD: 'mb-4',  // SAIL STANDARD: 16px
-    MORE: 'mb-6',      // SAIL MORE: 24px
-    EVEN_MORE: 'mb-8'  // SAIL EVEN_MORE: 32px
   }
 
   // Semantic color mappings — tags use light tints for backgrounds

--- a/src/components/Tag/TagField.tsx
+++ b/src/components/Tag/TagField.tsx
@@ -4,7 +4,7 @@ import type { SAILSize, SAILAlign, SAILLabelPosition, SAILMarginSize } from '../
 import { FieldLabel } from '../shared/FieldLabel'
 import { mergeClasses } from '../../utils/classNames'
 import { resolveColorClass, isSemanticColor, isPaletteColor } from '../../utils/colorResolver'
-import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
+import { marginAboveMap, marginBelowMap, alignMap } from '../../utils/sailMaps'
 
 /**
  * Tag size - only SMALL and STANDARD are supported per SAIL docs
@@ -70,13 +70,6 @@ export const TagField: React.FC<TagFieldProps> = ({
   const sizeMap = {
     SMALL: 'text-xs px-2 py-1',      // SAIL SMALL: 12px text, 8px horizontal padding, 4px vertical
     STANDARD: 'text-base px-4 py-1'  // SAIL STANDARD: 16px text, 16px horizontal padding, 4px vertical
-  }
-
-  // Alignment mappings
-  const alignMap = {
-    START: 'justify-start',
-    CENTER: 'justify-center',
-    END: 'justify-end'
   }
 
   // Semantic color mappings — tags use light tints for backgrounds

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import { FieldWrapper } from '../shared/FieldWrapper'
-import type { SAILLabelPosition, SAILMarginSize } from '../../types/sail'
+import type { SAILLabelPosition, SAILMarginSize, SAILAlignLegacy } from '../../types/sail'
+import { legacyTextAlignMap } from '../../utils/sailMaps'
 
 /**
  * Text alignment options for the input field
  */
-type TextAlign = "LEFT" | "CENTER" | "RIGHT"
+type TextAlign = SAILAlignLegacy
 
 /**
  * Input purpose for autocomplete hints (accessibility)
@@ -125,13 +126,6 @@ export const TextField: React.FC<TextFieldProps> = ({
   // Generate unique ID for label association
   const inputId = React.useMemo(() => `textfield-${Math.random().toString(36).substr(2, 9)}`, [])
 
-  // Map SAIL text alignment to Tailwind classes
-  const alignMap: Record<TextAlign, string> = {
-    LEFT: 'text-left',
-    CENTER: 'text-center',
-    RIGHT: 'text-right'
-  }
-
   // Map inputPurpose to autocomplete attribute
   const autoCompleteMap: Record<InputPurpose, string> = {
     NAME: 'name',
@@ -151,7 +145,7 @@ export const TextField: React.FC<TextFieldProps> = ({
   const inputClasses = [
     'w-full',
     'text-base',
-    alignMap[align],
+    legacyTextAlignMap[align],
     // ReadOnly mode: no border, no background, no padding (inline display)
     readOnly && 'border-none bg-transparent p-0',
     // Normal mode: standard input styling

--- a/src/components/Toggle/ToggleField.tsx
+++ b/src/components/Toggle/ToggleField.tsx
@@ -5,6 +5,7 @@ import { FieldWrapper } from '../shared/FieldWrapper'
 import type { SAILLabelPosition, SAILMarginSize, SAILSize, SAILColorInput } from '../../types/sail'
 import { isPaletteColor } from '../../utils/colorResolver'
 import { paletteColorMap } from '../../types/palette-colors.generated'
+import { buttonSizeMap } from '../../utils/sailMaps'
 
 type ToggleStyle = "SOLID" | "OUTLINE" | "GHOST"
 
@@ -96,14 +97,6 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
   if (!showWhen) return null
 
   const inputId = `togglefield-${Math.random().toString(36).substr(2, 9)}`
-
-  // Size mappings — matches ButtonWidget exactly
-  const sizeMap: Record<SAILSize, string> = {
-    SMALL: 'px-3 py-2 text-sm leading-none',
-    STANDARD: 'px-4 py-3 text-base leading-none',
-    MEDIUM: 'px-5 py-4 text-lg leading-none',
-    LARGE: 'px-6 py-5 text-xl leading-none'
-  }
 
   // Get color classes based on style and pressed state
   const getColorClasses = (): string => {
@@ -223,7 +216,7 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
         'inline-flex items-center justify-center gap-1',
         'font-medium transition-colors h-auto rounded-sm',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
-        sizeMap[size],
+        buttonSizeMap[size],
         getColorClasses(),
         disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
       ].filter(Boolean).join(' ')}

--- a/src/components/shared/FieldWrapper.tsx
+++ b/src/components/shared/FieldWrapper.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { FieldLabel } from './FieldLabel'
 import type { SAILLabelPosition, SAILMarginSize } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
+import { marginAboveMap, marginBelowMap } from '../../utils/sailMaps'
 
 export interface FieldWrapperProps {
   /** The label text to display */
@@ -51,25 +52,6 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
   footer,
   className
 }) => {
-  // Map SAIL margin values to Tailwind classes
-  const marginAboveMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mt-1',
-    LESS: 'mt-2',
-    STANDARD: 'mt-4',
-    MORE: 'mt-6',
-    EVEN_MORE: 'mt-8'
-  }
-
-  const marginBelowMap: Record<SAILMarginSize, string> = {
-    NONE: '',
-    EVEN_LESS: 'mb-1',
-    LESS: 'mb-2',
-    STANDARD: 'mb-4',
-    MORE: 'mb-6',
-    EVEN_MORE: 'mb-8'
-  }
-
   const sailClasses = [
     marginAboveMap[marginAbove],
     marginBelowMap[marginBelow],

--- a/src/types/sail.ts
+++ b/src/types/sail.ts
@@ -34,6 +34,16 @@ export type SAILSizeExtended = SAILSize | "MEDIUM_PLUS" | "LARGE_PLUS" | "EXTRA_
 export type SAILAlign = "START" | "CENTER" | "END"
 
 /**
+ * Legacy alignment values used by older SAIL components (text fields, rich text,
+ * checkboxes, links, editable grid headers). These components accept both the
+ * modern START/CENTER/END and the older LEFT/CENTER/RIGHT systems.
+ *
+ * See: Appian docs — older form-input components use LEFT/CENTER/RIGHT while
+ * newer display components use START/CENTER/END.
+ */
+export type SAILAlignLegacy = "START" | "CENTER" | "END" | "LEFT" | "RIGHT"
+
+/**
  * Label position values matching SAIL's labelPosition parameter
  */
 export type SAILLabelPosition = "ABOVE" | "ADJACENT" | "COLLAPSED" | "JUSTIFIED"

--- a/src/utils/sailMaps.ts
+++ b/src/utils/sailMaps.ts
@@ -1,0 +1,76 @@
+import type { SAILMarginSize, SAILPadding, SAILShape, SAILSize, SAILAlign } from '../types/sail'
+
+/**
+ * Canonical SAIL enum → Tailwind class mappings.
+ *
+ * These maps are the single source of truth for how SAIL parameter values
+ * translate to Tailwind utility classes. All components should import from
+ * here instead of defining their own copies.
+ *
+ * See: https://github.com/pglevy/sailwind/issues/83
+ */
+
+// --- Margin Maps ---
+
+export const marginAboveMap: Record<SAILMarginSize, string> = {
+  NONE: '',
+  EVEN_LESS: 'mt-1',
+  LESS: 'mt-2',
+  STANDARD: 'mt-4',
+  MORE: 'mt-6',
+  EVEN_MORE: 'mt-8'
+}
+
+export const marginBelowMap: Record<SAILMarginSize, string> = {
+  NONE: '',
+  EVEN_LESS: 'mb-1',
+  LESS: 'mb-2',
+  STANDARD: 'mb-4',
+  MORE: 'mb-6',
+  EVEN_MORE: 'mb-8'
+}
+
+// --- Padding Map ---
+
+export const paddingMap: Record<SAILPadding, string> = {
+  NONE: 'p-0',
+  EVEN_LESS: 'p-1',
+  LESS: 'p-2',
+  STANDARD: 'p-4',
+  MORE: 'p-6',
+  EVEN_MORE: 'p-8'
+}
+
+// --- Shape Map ---
+
+export const shapeMap: Record<SAILShape, string> = {
+  SQUARED: 'rounded-none',
+  SEMI_ROUNDED: 'rounded-sm',
+  ROUNDED: 'rounded-md'
+}
+
+// --- Button / Interactive Size Maps ---
+
+/** Size classes for labeled buttons, tabs, and toggles */
+export const buttonSizeMap: Record<SAILSize, string> = {
+  SMALL: 'px-3 py-2 text-sm leading-none',
+  STANDARD: 'px-4 py-3 text-base leading-none',
+  MEDIUM: 'px-5 py-4 text-lg leading-none',
+  LARGE: 'px-6 py-5 text-xl leading-none'
+}
+
+/** Size classes for icon-only buttons (uniform padding for square aspect ratio) */
+export const buttonIconOnlySizeMap: Record<SAILSize, string> = {
+  SMALL: 'p-2 text-sm',
+  STANDARD: 'p-3 text-base',
+  MEDIUM: 'p-4 text-lg',
+  LARGE: 'p-5 text-xl'
+}
+
+// --- Alignment Map ---
+
+export const alignMap: Record<SAILAlign, string> = {
+  START: 'justify-start',
+  CENTER: 'justify-center',
+  END: 'justify-end'
+}

--- a/src/utils/sailMaps.ts
+++ b/src/utils/sailMaps.ts
@@ -67,10 +67,18 @@ export const buttonIconOnlySizeMap: Record<SAILSize, string> = {
   LARGE: 'p-5 text-xl'
 }
 
-// --- Alignment Map ---
+// --- Alignment Maps ---
 
+/** Flex alignment (for button arrays, tags, images, stamps) */
 export const alignMap: Record<SAILAlign, string> = {
   START: 'justify-start',
   CENTER: 'justify-center',
   END: 'justify-end'
+}
+
+/** Text alignment (for headings, rich text, text fields) */
+export const textAlignMap: Record<SAILAlign, string> = {
+  START: 'text-left',
+  CENTER: 'text-center',
+  END: 'text-right'
 }

--- a/src/utils/sailMaps.ts
+++ b/src/utils/sailMaps.ts
@@ -1,4 +1,4 @@
-import type { SAILMarginSize, SAILPadding, SAILShape, SAILSize, SAILAlign } from '../types/sail'
+import type { SAILMarginSize, SAILPadding, SAILShape, SAILSize, SAILAlign, SAILAlignLegacy } from '../types/sail'
 
 /**
  * Canonical SAIL enum → Tailwind class mappings.
@@ -69,16 +69,41 @@ export const buttonIconOnlySizeMap: Record<SAILSize, string> = {
 
 // --- Alignment Maps ---
 
-/** Flex alignment (for button arrays, tags, images, stamps) */
+/** Flex alignment (for button arrays, tags, images, stamps — modern START/CENTER/END only) */
 export const alignMap: Record<SAILAlign, string> = {
   START: 'justify-start',
   CENTER: 'justify-center',
   END: 'justify-end'
 }
 
-/** Text alignment (for headings, rich text, text fields) */
+/** Text alignment (for headings — modern START/CENTER/END only) */
 export const textAlignMap: Record<SAILAlign, string> = {
   START: 'text-left',
   CENTER: 'text-center',
   END: 'text-right'
+}
+
+// --- Legacy Alignment Maps ---
+//
+// Older SAIL components (text fields, rich text, checkboxes, links, editable
+// grid headers) use LEFT/CENTER/RIGHT. These backward-compatible maps accept
+// both the modern START/CENTER/END *and* the legacy LEFT/CENTER/RIGHT so that
+// LLM-generated code works regardless of which convention it picks.
+
+/** Flex alignment — backward-compatible (for checkboxes, links in grids) */
+export const legacyAlignMap: Record<SAILAlignLegacy, string> = {
+  START: 'justify-start',
+  LEFT: 'justify-start',
+  CENTER: 'justify-center',
+  END: 'justify-end',
+  RIGHT: 'justify-end'
+}
+
+/** Text alignment — backward-compatible (for text fields, rich text, integer/decimal fields) */
+export const legacyTextAlignMap: Record<SAILAlignLegacy, string> = {
+  START: 'text-left',
+  LEFT: 'text-left',
+  CENTER: 'text-center',
+  END: 'text-right',
+  RIGHT: 'text-right'
 }


### PR DESCRIPTION
Closes #83 (Phase 1)

Creates `src/utils/sailMaps.ts` as the single source of truth for SAIL enum → Tailwind class mappings, and refactors 14 components to import from it instead of defining their own copies.

**Shared maps created:**
- `marginAboveMap` / `marginBelowMap` (was duplicated across 12 components)
- `paddingMap` (CardLayout)
- `shapeMap` (CardLayout, MessageBanner)
- `buttonSizeMap` / `buttonIconOnlySizeMap` (ButtonWidget, TabsField, ToggleField)
- `alignMap` (ButtonArrayLayout)

**Components updated:**
FieldWrapper, CardLayout, HeadingField, ButtonWidget, ButtonArrayLayout, TagField, MessageBanner, StampField, RichTextDisplayField, DialogField, ProgressBar, MilestoneField, TabsField, ToggleField

**Notes:**
- StampField `shapeMap` intentionally kept local — uses `rounded-full` for ROUNDED (circular stamps) vs the shared `rounded-md`
- TabsField naming standardized: `marginMap` → `marginAboveMap`, `marginBottomMap` → `marginBelowMap`
- Pure refactor — no visual changes, no logic changes, no value changes
- Phase 2 (token-driven generation from tokens.json) tracked in spec
