### PR TITLE
Migrate Propeller Chat components

### DIFF
--- a/src/components/Chat/ChatConfirmation.stories.tsx
+++ b/src/components/Chat/ChatConfirmation.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ChatConfirmation } from './ChatConfirmation'
+
+const meta = {
+  title: 'Components/Chat/ChatConfirmation',
+  component: ChatConfirmation,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 500 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ChatConfirmation>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    message: "Next, I'll create the document record type for handling file attachments. Should I proceed with this task?",
+    primaryAction: {
+      label: 'Yes, continue',
+      onClick: () => console.log('Confirmed'),
+    },
+  },
+}
+
+export const WithSecondaryAction: Story = {
+  args: {
+    message: 'This action will modify your database schema. Are you sure you want to proceed?',
+    primaryAction: {
+      label: 'Yes, proceed',
+      onClick: () => console.log('Confirmed'),
+    },
+    secondaryAction: {
+      label: 'No, cancel',
+      onClick: () => console.log('Cancelled'),
+    },
+  },
+}
+
+export const LongMessage: Story = {
+  args: {
+    message: "I've analyzed your codebase and identified several potential improvements. This includes refactoring the authentication system, updating dependencies, optimizing database queries, and implementing better error handling. Would you like me to proceed with these changes?",
+    primaryAction: {
+      label: 'Yes, continue',
+      onClick: () => console.log('Confirmed'),
+    },
+    secondaryAction: {
+      label: 'No, skip this',
+      onClick: () => console.log('Cancelled'),
+    },
+  },
+}
+
+export const Completed: Story = {
+  args: {
+    message: "Next, I'll create the document record type for handling file attachments. Should I proceed with this task?",
+    primaryAction: {
+      label: 'Yes, continue',
+      onClick: () => console.log('Confirmed'),
+    },
+    completed: true,
+  },
+}

--- a/src/components/Chat/ChatConfirmation.tsx
+++ b/src/components/Chat/ChatConfirmation.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import { useState } from 'react'
+import { mergeClasses } from '../../utils/classNames'
+
+export interface ChatConfirmationAction {
+  label: string
+  onClick: () => void
+}
+
+export interface ChatConfirmationProps {
+  /** Confirmation message to display */
+  message: string
+  /** Primary action button */
+  primaryAction: ChatConfirmationAction
+  /** Optional secondary action button */
+  secondaryAction?: ChatConfirmationAction
+  /** Whether the confirmation has been acted on */
+  completed?: boolean
+  /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
+  className?: string
+}
+
+export const ChatConfirmation: React.FC<ChatConfirmationProps> = ({
+  message,
+  primaryAction,
+  secondaryAction,
+  completed: controlledCompleted,
+  className,
+}) => {
+  const [internalCompleted, setInternalCompleted] = useState(false)
+  const completed = controlledCompleted ?? internalCompleted
+
+  const handleClick = (action: ChatConfirmationAction) => {
+    setInternalCompleted(true)
+    action.onClick()
+  }
+
+  const sailClasses = `bg-blue-50 border-l-4 px-5 py-4${completed ? ' border-blue-200' : ' border-blue-500'}`
+
+  return (
+    <div role="alert" className={mergeClasses(sailClasses, className)}>
+      <p className={`text-base ${completed ? 'text-gray-700' : 'text-gray-900'}`}>{message}</p>
+      <div className="flex gap-2 mt-2">
+        <button
+          onClick={() => handleClick(primaryAction)}
+          disabled={completed}
+          className={`px-4 py-2 text-base font-medium rounded-sm transition-colors ${completed ? 'bg-blue-500 text-white opacity-50 cursor-not-allowed' : 'bg-blue-500 text-white hover:bg-blue-700'}`}
+        >
+          {primaryAction.label}
+        </button>
+        {secondaryAction && (
+          <button
+            onClick={() => handleClick(secondaryAction)}
+            disabled={completed}
+            className={`px-4 py-2 text-base font-medium rounded-sm border transition-colors ${completed ? 'border-gray-200 text-gray-700 bg-white opacity-50 cursor-not-allowed' : 'border-gray-200 text-gray-700 bg-white hover:bg-gray-100'}`}
+          >
+            {secondaryAction.label}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Chat/ChatConfirmation.tsx
+++ b/src/components/Chat/ChatConfirmation.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useState } from 'react'
 import { mergeClasses } from '../../utils/classNames'
+import { ButtonWidget } from '../Button/ButtonWidget'
 
 export interface ChatConfirmationAction {
   label: string
@@ -28,10 +29,11 @@ export const ChatConfirmation: React.FC<ChatConfirmationProps> = ({
   className,
 }) => {
   const [internalCompleted, setInternalCompleted] = useState(false)
-  const completed = controlledCompleted ?? internalCompleted
+  const isControlled = controlledCompleted !== undefined
+  const completed = isControlled ? controlledCompleted : internalCompleted
 
   const handleClick = (action: ChatConfirmationAction) => {
-    setInternalCompleted(true)
+    if (!isControlled) setInternalCompleted(true)
     action.onClick()
   }
 
@@ -41,21 +43,21 @@ export const ChatConfirmation: React.FC<ChatConfirmationProps> = ({
     <div role="alert" className={mergeClasses(sailClasses, className)}>
       <p className={`text-base ${completed ? 'text-gray-700' : 'text-gray-900'}`}>{message}</p>
       <div className="flex gap-2 mt-2">
-        <button
-          onClick={() => handleClick(primaryAction)}
+        <ButtonWidget
+          label={primaryAction.label}
+          style="SOLID"
+          color="ACCENT"
           disabled={completed}
-          className={`px-4 py-2 text-base font-medium rounded-sm transition-colors ${completed ? 'bg-blue-500 text-white opacity-50 cursor-not-allowed' : 'bg-blue-500 text-white hover:bg-blue-700'}`}
-        >
-          {primaryAction.label}
-        </button>
+          onClick={() => handleClick(primaryAction)}
+        />
         {secondaryAction && (
-          <button
-            onClick={() => handleClick(secondaryAction)}
+          <ButtonWidget
+            label={secondaryAction.label}
+            style="OUTLINE"
+            color="SECONDARY"
             disabled={completed}
-            className={`px-4 py-2 text-base font-medium rounded-sm border transition-colors ${completed ? 'border-gray-200 text-gray-700 bg-white opacity-50 cursor-not-allowed' : 'border-gray-200 text-gray-700 bg-white hover:bg-gray-100'}`}
-          >
-            {secondaryAction.label}
-          </button>
+            onClick={() => handleClick(secondaryAction)}
+          />
         )}
       </div>
     </div>

--- a/src/components/Chat/ChatFeedback.stories.tsx
+++ b/src/components/Chat/ChatFeedback.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
   parameters: { layout: 'centered' },
   args: {
     onFeedbackSubmit: fn(),
-    feedbackOptions,
+    feedbackOptions: feedbackOptions,
   },
 } satisfies Meta<typeof ChatFeedback>
 
@@ -35,17 +35,23 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
+export const WithoutDialog: Story = {
+  args: {
+    showDetailsDialog: false,
+  },
+}
+
 export const AgentEvaluationVariant: Story = {
   args: {
-    variant: 'AGENT_EVALUATION',
+    style: 'AGENT_EVALUATION',
   },
 }
 
 export const DialogWithCustomization: Story = {
   args: {
-    variant: 'AGENT_EVALUATION',
+    style: 'AGENT_EVALUATION',
     showDetailsDialog: true,
-    showCheckboxOptions: true,
+    showFeedbackOptions: true,
     dialogConfig: {
       title: 'Provide feedback',
       description: 'Help us improve',
@@ -89,7 +95,7 @@ export const DefaultInteraction: Story = {
 
 export const AgentEvaluationInteraction: Story = {
   args: {
-    variant: 'AGENT_EVALUATION',
+    style: 'AGENT_EVALUATION',
   },
   tags: ['test-only', '!autodocs'],
   parameters: { chromatic: { disableSnapshot: true } },

--- a/src/components/Chat/ChatFeedback.stories.tsx
+++ b/src/components/Chat/ChatFeedback.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { fn, userEvent, within, expect, waitFor } from 'storybook/test'
+import { ChatFeedback } from './ChatFeedback'
+
+const feedbackOptions = {
+  positive: [
+    { id: 'accurate', label: 'Accurate information' },
+    { id: 'helpful', label: 'Helpful response' },
+    { id: 'clear', label: 'Clear and concise' },
+    { id: 'complete', label: 'Complete answer' },
+    { id: 'other', label: 'Other' },
+  ],
+  negative: [
+    { id: 'incorrect', label: 'Incorrect information' },
+    { id: 'incomplete', label: 'Incomplete answer' },
+    { id: 'unclear', label: 'Unclear or confusing' },
+    { id: 'irrelevant', label: 'Not relevant to my question' },
+    { id: 'other', label: 'Other' },
+  ],
+}
+
+const meta = {
+  title: 'Components/Chat/ChatFeedback',
+  component: ChatFeedback,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    onFeedbackSubmit: fn(),
+    feedbackOptions,
+  },
+} satisfies Meta<typeof ChatFeedback>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const AgentEvaluationVariant: Story = {
+  args: {
+    variant: 'AGENT_EVALUATION',
+  },
+}
+
+export const DialogWithCustomization: Story = {
+  args: {
+    variant: 'AGENT_EVALUATION',
+    showDetailsDialog: true,
+    showCheckboxOptions: true,
+    dialogConfig: {
+      title: 'Provide feedback',
+      description: 'Help us improve',
+      placeholder: 'Please provide additional details...',
+      submitText: 'Submit',
+      cancelText: 'Cancel',
+    },
+  },
+}
+
+export const DefaultInteraction: Story = {
+  tags: ['test-only', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const body = within(document.body)
+
+    const thumbsUpButton = canvas.getByLabelText('Helpful')
+    await userEvent.click(thumbsUpButton)
+    await body.findByRole('dialog')
+
+    const dialogTitle = body.getByText('Feedback')
+    await expect(dialogTitle).toBeInTheDocument()
+
+    const accurateCheckbox = body.getByLabelText('Accurate information')
+    await expect(accurateCheckbox).toBeInTheDocument()
+    await userEvent.click(accurateCheckbox)
+    await expect(accurateCheckbox).toBeChecked()
+
+    const commentField = body.getByPlaceholderText('Enter your feedback...')
+    await userEvent.type(commentField, 'Great response!')
+
+    const submitButton = body.getByRole('button', { name: 'Submit' })
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(body.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  },
+}
+
+export const AgentEvaluationInteraction: Story = {
+  args: {
+    variant: 'AGENT_EVALUATION',
+  },
+  tags: ['test-only', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const body = within(document.body)
+
+    const thumbsDownButton = canvas.getByLabelText('Not helpful')
+    await userEvent.click(thumbsDownButton)
+    await body.findByRole('dialog')
+
+    const incorrectCheckbox = body.getByLabelText('Incorrect information')
+    await expect(incorrectCheckbox).toBeInTheDocument()
+
+    const otherCheckbox = body.getByLabelText('Other')
+    await userEvent.click(otherCheckbox)
+    await expect(otherCheckbox).toBeChecked()
+
+    const commentLabel = body.getByText(/Additional comments/)
+    await expect(commentLabel).toBeInTheDocument()
+    await expect(commentLabel.textContent).toContain('*')
+
+    const submitButton = body.getByRole('button', { name: 'Submit' })
+    await userEvent.click(submitButton)
+    await expect(body.getByRole('dialog')).toBeInTheDocument()
+
+    const commentField = body.getByPlaceholderText('Enter your feedback...')
+    await userEvent.type(commentField, 'The information was outdated')
+
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(body.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  },
+}

--- a/src/components/Chat/ChatFeedback.tsx
+++ b/src/components/Chat/ChatFeedback.tsx
@@ -1,0 +1,226 @@
+import * as React from 'react'
+import { useState } from 'react'
+import { ThumbsUp, ThumbsDown } from 'lucide-react'
+import { mergeClasses } from '../../utils/classNames'
+import { CheckboxField } from '../Checkbox/CheckboxField'
+import { DialogField } from '../Dialog/DialogField'
+import { ButtonWidget } from '../Button/ButtonWidget'
+
+export interface FeedbackOption {
+  id: string
+  label: string
+}
+
+export interface FeedbackOptions {
+  /** Checkbox options shown when thumbs up is selected */
+  positive?: FeedbackOption[]
+  /** Checkbox options shown when thumbs down is selected */
+  negative?: FeedbackOption[]
+}
+
+export interface FeedbackDetails {
+  /** The user's thumbs up or down selection */
+  feedback: 'up' | 'down'
+  /** Optional free-form text feedback */
+  comment?: string
+  /** Array of selected checkbox option IDs */
+  selectedOptions?: string[]
+}
+
+type ChatFeedbackVariant = 'DEFAULT' | 'AGENT_EVALUATION'
+
+export interface ChatFeedbackProps {
+  /**
+   * Color scheme variant
+   * - "DEFAULT": Blue icon when selected, no background
+   * - "AGENT_EVALUATION": Thumbs up uses green, thumbs down uses red with backgrounds
+   */
+  variant?: ChatFeedbackVariant
+  /** Whether clicking thumbs up/down should open a dialog for detailed feedback */
+  showDetailsDialog?: boolean
+  /** Whether to show checkbox options in the dialog */
+  showCheckboxOptions?: boolean
+  /** Predefined checkbox options for categorizing feedback */
+  feedbackOptions?: FeedbackOptions
+  /** Custom dialog configuration */
+  dialogConfig?: {
+    title?: string
+    description?: string
+    placeholder?: string
+    submitText?: string
+    cancelText?: string
+  }
+  /** Callback when feedback is submitted */
+  onFeedbackSubmit?: (details: FeedbackDetails) => void
+  /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
+  className?: string
+}
+
+export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
+  variant = 'DEFAULT',
+  showDetailsDialog = true,
+  showCheckboxOptions = true,
+  feedbackOptions,
+  dialogConfig,
+  onFeedbackSubmit,
+  className,
+}) => {
+  const [feedback, setFeedback] = useState<'up' | 'down' | null>(null)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [feedbackComment, setFeedbackComment] = useState('')
+  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
+
+  const handleFeedbackClick = (type: 'up' | 'down') => {
+    if (showDetailsDialog) {
+      setFeedback(type)
+      setIsDialogOpen(true)
+    } else {
+      const newFeedback = feedback === type ? null : type
+      setFeedback(newFeedback)
+      if (newFeedback && onFeedbackSubmit) {
+        onFeedbackSubmit({ feedback: newFeedback })
+      }
+    }
+  }
+
+  const handleSubmitDetails = () => {
+    if (!feedback) return
+    const isOtherSelected = selectedOptions.includes('other')
+    if (isOtherSelected && !feedbackComment.trim()) {
+      setHasAttemptedSubmit(true)
+      return
+    }
+    onFeedbackSubmit?.({
+      feedback,
+      comment: feedbackComment || undefined,
+      selectedOptions: selectedOptions.length > 0 ? selectedOptions : undefined,
+    })
+    setIsDialogOpen(false)
+    setFeedbackComment('')
+    setSelectedOptions([])
+    setHasAttemptedSubmit(false)
+  }
+
+  const handleCancel = () => {
+    setIsDialogOpen(false)
+    setFeedbackComment('')
+    setSelectedOptions([])
+    setHasAttemptedSubmit(false)
+    setFeedback(null)
+  }
+
+  const dialogTitle = dialogConfig?.title || 'Feedback'
+  const defaultDescription = feedback === 'up'
+    ? 'What was good about this response?'
+    : 'What was the issue with this response?'
+  const dialogDescription = dialogConfig?.description || defaultDescription
+  const placeholder = dialogConfig?.placeholder || 'Enter your feedback...'
+  const submitText = dialogConfig?.submitText || 'Submit'
+  const cancelText = dialogConfig?.cancelText || 'Cancel'
+
+  const currentCheckboxOptions = feedback === 'up'
+    ? feedbackOptions?.positive
+    : feedbackOptions?.negative
+
+  const isOtherSelected = selectedOptions.includes('other')
+  const isCommentRequired = isOtherSelected
+  const showValidationError = hasAttemptedSubmit && isCommentRequired && !feedbackComment.trim()
+
+  const getButtonClasses = (type: 'up' | 'down', isSelected: boolean) => {
+    const base = 'p-1.5 rounded-md transition-colors'
+    if (!isSelected) return `${base} text-gray-500 hover:text-gray-700 hover:bg-gray-100`
+    if (variant === 'DEFAULT') return `${base} text-blue-500`
+    if (type === 'up') return `${base} bg-green-50 text-green-700`
+    return `${base} bg-red-50 text-red-700`
+  }
+
+  const sailClasses = 'flex items-center gap-1 bg-white'
+
+  return (
+    <>
+      <div className={mergeClasses(sailClasses, className)}>
+        <div className="flex gap-1">
+          <button
+            onClick={() => handleFeedbackClick('up')}
+            aria-label="Helpful"
+            className={getButtonClasses('up', feedback === 'up')}
+          >
+            <ThumbsUp size={16} />
+          </button>
+          <button
+            onClick={() => handleFeedbackClick('down')}
+            aria-label="Not helpful"
+            className={getButtonClasses('down', feedback === 'down')}
+          >
+            <ThumbsDown size={16} />
+          </button>
+        </div>
+      </div>
+
+      <DialogField
+        open={isDialogOpen}
+        onOpenChange={(open) => { if (!open) handleCancel() }}
+        title={dialogTitle}
+        description={dialogDescription}
+        width="MEDIUM"
+        marginBelow="NONE"
+        marginAbove="NONE"
+      >
+        <div className="space-y-4">
+          {showCheckboxOptions && currentCheckboxOptions && currentCheckboxOptions.length > 0 && (
+            <CheckboxField
+              choiceLabels={currentCheckboxOptions.map(o => o.label)}
+              choiceValues={currentCheckboxOptions.map(o => o.id)}
+              value={selectedOptions}
+              onChange={setSelectedOptions}
+              labelPosition="COLLAPSED"
+              marginBelow="NONE"
+              marginAbove="NONE"
+            />
+          )}
+
+          <div className="space-y-2">
+            {showCheckboxOptions && (
+              <label htmlFor="feedback-comment" className="text-sm font-medium text-gray-900">
+                Additional comments{isCommentRequired && <span className="text-red-700 ml-1">*</span>}
+              </label>
+            )}
+            <textarea
+              id="feedback-comment"
+              value={feedbackComment}
+              onChange={(e) => setFeedbackComment(e.target.value)}
+              placeholder={placeholder}
+              rows={4}
+              required={isCommentRequired}
+              aria-required={isCommentRequired}
+              aria-describedby={showValidationError ? 'feedback-comment-error' : undefined}
+              aria-invalid={showValidationError}
+              className="w-full min-h-32 resize-none rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:border-blue-500 transition-colors"
+            />
+            {showValidationError && (
+              <p id="feedback-comment-error" role="alert" className="text-xs text-red-700">
+                Please provide additional details when selecting &quot;Other&quot;
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <ButtonWidget
+              label={cancelText}
+              style="OUTLINE"
+              color="SECONDARY"
+              onClick={handleCancel}
+            />
+            <ButtonWidget
+              label={submitText}
+              style="SOLID"
+              color="ACCENT"
+              onClick={handleSubmitDetails}
+            />
+          </div>
+        </div>
+      </DialogField>
+    </>
+  )
+}

--- a/src/components/Chat/ChatFeedback.tsx
+++ b/src/components/Chat/ChatFeedback.tsx
@@ -4,7 +4,8 @@ import { ThumbsUp, ThumbsDown } from 'lucide-react'
 import { mergeClasses } from '../../utils/classNames'
 import { CheckboxField } from '../Checkbox/CheckboxField'
 import { DialogField } from '../Dialog/DialogField'
-import { ButtonWidget } from '../Button/ButtonWidget'
+import { ButtonArrayLayout } from '../Button/ButtonArrayLayout'
+import { ParagraphField } from '../ParagraphField/ParagraphField'
 
 export interface FeedbackOption {
   id: string
@@ -19,28 +20,28 @@ export interface FeedbackOptions {
 }
 
 export interface FeedbackDetails {
-  /** The user's thumbs up or down selection */
-  feedback: 'up' | 'down'
+  /** The user's positive or negative selection */
+  feedback: 'positive' | 'negative'
   /** Optional free-form text feedback */
   comment?: string
   /** Array of selected checkbox option IDs */
   selectedOptions?: string[]
 }
 
-type ChatFeedbackVariant = 'DEFAULT' | 'AGENT_EVALUATION'
+type ChatFeedbackStyle = 'DEFAULT' | 'AGENT_EVALUATION'
 
 export interface ChatFeedbackProps {
   /**
-   * Color scheme variant
+   * Color scheme style
    * - "DEFAULT": Blue icon when selected, no background
    * - "AGENT_EVALUATION": Thumbs up uses green, thumbs down uses red with backgrounds
    */
-  variant?: ChatFeedbackVariant
+  style?: ChatFeedbackStyle
   /** Whether clicking thumbs up/down should open a dialog for detailed feedback */
   showDetailsDialog?: boolean
-  /** Whether to show checkbox options in the dialog */
-  showCheckboxOptions?: boolean
-  /** Predefined checkbox options for categorizing feedback */
+  /** Whether to show selectable options in the dialog */
+  showFeedbackOptions?: boolean
+  /** Selectable options for categorizing feedback */
   feedbackOptions?: FeedbackOptions
   /** Custom dialog configuration */
   dialogConfig?: {
@@ -57,21 +58,21 @@ export interface ChatFeedbackProps {
 }
 
 export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
-  variant = 'DEFAULT',
+  style = 'DEFAULT',
   showDetailsDialog = true,
-  showCheckboxOptions = true,
+  showFeedbackOptions = true,
   feedbackOptions,
   dialogConfig,
   onFeedbackSubmit,
   className,
 }) => {
-  const [feedback, setFeedback] = useState<'up' | 'down' | null>(null)
+  const [feedback, setFeedback] = useState<'positive' | 'negative' | null>(null)
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [feedbackComment, setFeedbackComment] = useState('')
   const [selectedOptions, setSelectedOptions] = useState<string[]>([])
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
 
-  const handleFeedbackClick = (type: 'up' | 'down') => {
+  const handleFeedbackClick = (type: 'positive' | 'negative') => {
     if (showDetailsDialog) {
       setFeedback(type)
       setIsDialogOpen(true)
@@ -111,7 +112,7 @@ export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
   }
 
   const dialogTitle = dialogConfig?.title || 'Feedback'
-  const defaultDescription = feedback === 'up'
+  const defaultDescription = feedback === 'positive'
     ? 'What was good about this response?'
     : 'What was the issue with this response?'
   const dialogDescription = dialogConfig?.description || defaultDescription
@@ -119,7 +120,7 @@ export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
   const submitText = dialogConfig?.submitText || 'Submit'
   const cancelText = dialogConfig?.cancelText || 'Cancel'
 
-  const currentCheckboxOptions = feedback === 'up'
+  const currentCheckboxOptions = feedback === 'positive'
     ? feedbackOptions?.positive
     : feedbackOptions?.negative
 
@@ -127,11 +128,11 @@ export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
   const isCommentRequired = isOtherSelected
   const showValidationError = hasAttemptedSubmit && isCommentRequired && !feedbackComment.trim()
 
-  const getButtonClasses = (type: 'up' | 'down', isSelected: boolean) => {
+  const getButtonClasses = (type: 'positive' | 'negative', isSelected: boolean) => {
     const base = 'p-1.5 rounded-md transition-colors'
     if (!isSelected) return `${base} text-gray-500 hover:text-gray-700 hover:bg-gray-100`
-    if (variant === 'DEFAULT') return `${base} text-blue-500`
-    if (type === 'up') return `${base} bg-green-50 text-green-700`
+    if (style === 'DEFAULT') return `${base} text-blue-500`
+    if (type === 'positive') return `${base} bg-green-50 text-green-700`
     return `${base} bg-red-50 text-red-700`
   }
 
@@ -142,16 +143,16 @@ export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
       <div className={mergeClasses(sailClasses, className)}>
         <div className="flex gap-1">
           <button
-            onClick={() => handleFeedbackClick('up')}
+            onClick={() => handleFeedbackClick('positive')}
             aria-label="Helpful"
-            className={getButtonClasses('up', feedback === 'up')}
+            className={getButtonClasses('positive', feedback === 'positive')}
           >
             <ThumbsUp size={16} />
           </button>
           <button
-            onClick={() => handleFeedbackClick('down')}
+            onClick={() => handleFeedbackClick('negative')}
             aria-label="Not helpful"
-            className={getButtonClasses('down', feedback === 'down')}
+            className={getButtonClasses('negative', feedback === 'negative')}
           >
             <ThumbsDown size={16} />
           </button>
@@ -168,7 +169,7 @@ export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
         marginAbove="NONE"
       >
         <div className="space-y-4">
-          {showCheckboxOptions && currentCheckboxOptions && currentCheckboxOptions.length > 0 && (
+          {showFeedbackOptions && currentCheckboxOptions && currentCheckboxOptions.length > 0 && (
             <CheckboxField
               choiceLabels={currentCheckboxOptions.map(o => o.label)}
               choiceValues={currentCheckboxOptions.map(o => o.id)}
@@ -180,45 +181,27 @@ export const ChatFeedback: React.FC<ChatFeedbackProps> = ({
             />
           )}
 
-          <div className="space-y-2">
-            {showCheckboxOptions && (
-              <label htmlFor="feedback-comment" className="text-sm font-medium text-gray-900">
-                Additional comments{isCommentRequired && <span className="text-red-700 ml-1">*</span>}
-              </label>
-            )}
-            <textarea
-              id="feedback-comment"
-              value={feedbackComment}
-              onChange={(e) => setFeedbackComment(e.target.value)}
-              placeholder={placeholder}
-              rows={4}
-              required={isCommentRequired}
-              aria-required={isCommentRequired}
-              aria-describedby={showValidationError ? 'feedback-comment-error' : undefined}
-              aria-invalid={showValidationError}
-              className="w-full min-h-32 resize-none rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:border-blue-500 transition-colors"
-            />
-            {showValidationError && (
-              <p id="feedback-comment-error" role="alert" className="text-xs text-red-700">
-                Please provide additional details when selecting &quot;Other&quot;
-              </p>
-            )}
-          </div>
+          <ParagraphField
+            label={showFeedbackOptions ? 'Additional comments' : undefined}
+            labelPosition={showFeedbackOptions ? 'ABOVE' : 'COLLAPSED'}
+            required={isCommentRequired}
+            validations={showValidationError ? ['Please provide additional details when selecting "Other"'] : []}
+            value={feedbackComment}
+            saveInto={setFeedbackComment}
+            placeholder={placeholder}
+            height="SHORT"
+            marginBelow="NONE"
+            marginAbove="NONE"
+          />
 
-          <div className="flex justify-end gap-2">
-            <ButtonWidget
-              label={cancelText}
-              style="OUTLINE"
-              color="SECONDARY"
-              onClick={handleCancel}
-            />
-            <ButtonWidget
-              label={submitText}
-              style="SOLID"
-              color="ACCENT"
-              onClick={handleSubmitDetails}
-            />
-          </div>
+          <ButtonArrayLayout
+            align="END"
+            buttons={[
+              { label: cancelText, style: "OUTLINE", color: "SECONDARY", onClick: handleCancel },
+              { label: submitText, style: "SOLID", color: "ACCENT", onClick: handleSubmitDetails },
+            ]}
+            marginBelow="NONE"
+          />
         </div>
       </DialogField>
     </>

--- a/src/components/Chat/ChatInput.stories.tsx
+++ b/src/components/Chat/ChatInput.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { fn, userEvent, within, expect } from 'storybook/test'
+import { ChatInput } from './ChatInput'
+
+const meta = {
+  title: 'Components/Chat/ChatInput',
+  component: ChatInput,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    onSubmit: fn(),
+  },
+} satisfies Meta<typeof ChatInput>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithPlaceholder: Story = {
+  args: {
+    placeholder: 'Ask me anything...',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
+export const WithUpload: Story = {
+  args: {
+    showUpload: true,
+  },
+}
+
+export const TypeAndSubmit: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+    const textarea = canvas.getByPlaceholderText('Type a message...')
+    const sendButton = canvas.getByRole('button')
+
+    await expect(sendButton).toBeDisabled()
+    await userEvent.type(textarea, 'Hello, world!')
+    await expect(sendButton).toBeEnabled()
+    await userEvent.click(sendButton)
+    await expect(args.onSubmit).toHaveBeenCalledWith('Hello, world!')
+    await expect(textarea).toHaveValue('')
+  },
+}
+
+export const SubmitWithEnter: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+    const textarea = canvas.getByPlaceholderText('Type a message...')
+
+    await userEvent.type(textarea, 'Hello!{Enter}')
+    await expect(args.onSubmit).toHaveBeenCalledWith('Hello!')
+  },
+}

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react'
+import { useState } from 'react'
+import { Send, Paperclip, X, FileText, FileImage, FileVideo, File } from 'lucide-react'
+import { mergeClasses } from '../../utils/classNames'
+
+export interface ChatInputFile {
+  name: string
+  type?: string
+}
+
+export interface ChatInputProps {
+  /** Placeholder text for the input */
+  placeholder?: string
+  /** Callback when message is submitted */
+  onSubmit?: (message: string) => void
+  /** Whether the input is disabled */
+  disabled?: boolean
+  /** Value of the input (controlled) */
+  value?: string
+  /** Callback when value changes (controlled) */
+  onChange?: (value: string) => void
+  /** Whether to show the upload/attach button */
+  showUpload?: boolean
+  /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
+  className?: string
+}
+
+const getFileIcon = (type?: string) => {
+  if (!type) return File
+  if (type.startsWith('image/')) return FileImage
+  if (type.startsWith('video/')) return FileVideo
+  if (type === 'application/pdf' || type.startsWith('text/')) return FileText
+  return File
+}
+
+const getFileIconColor = (type?: string) => {
+  if (!type) return 'text-gray-500'
+  if (type.startsWith('image/')) return 'text-blue-500'
+  if (type.startsWith('video/')) return 'text-red-500'
+  if (type === 'application/pdf') return 'text-red-700'
+  if (type.startsWith('text/')) return 'text-blue-700'
+  return 'text-gray-500'
+}
+
+export const ChatInput: React.FC<ChatInputProps> = ({
+  placeholder = 'Type a message...',
+  onSubmit,
+  disabled = false,
+  value: controlledValue,
+  onChange,
+  showUpload = false,
+  className,
+}) => {
+  const [internalValue, setInternalValue] = useState('')
+  const [files, setFiles] = useState<ChatInputFile[]>([])
+
+  const isControlled = controlledValue !== undefined
+  const value = isControlled ? controlledValue : internalValue
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value
+    if (isControlled) {
+      onChange?.(newValue)
+    } else {
+      setInternalValue(newValue)
+    }
+  }
+
+  const handleSubmit = () => {
+    if (value.trim() && onSubmit) {
+      onSubmit(value)
+      if (!isControlled) {
+        setInternalValue('')
+      }
+      setFiles([])
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  const handleUploadClick = () => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.multiple = true
+    input.onchange = (e) => {
+      const selected = (e.target as HTMLInputElement).files
+      if (selected) {
+        const newFiles = Array.from(selected).map(f => ({ name: f.name, type: f.type }))
+        setFiles(prev => [...prev, ...newFiles])
+      }
+    }
+    input.click()
+  }
+
+  const sailClasses = 'flex items-end gap-2 pr-1 pb-1 border border-gray-300 rounded-md focus-within:border-blue-500 transition-colors'
+
+  return (
+    <div className={mergeClasses(sailClasses, className)}>
+      <div className="flex flex-col flex-1">
+        {files.length > 0 && (
+          <div className="flex flex-col gap-1 px-3 pt-2">
+            {files.map((file, index) => {
+              const IconComponent = getFileIcon(file.type)
+              const iconColor = getFileIconColor(file.type)
+              return (
+                <div
+                  key={index}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-gray-200 bg-white w-fit max-w-full"
+                >
+                  <IconComponent size={16} className={`shrink-0 ${iconColor}`} />
+                  <span className="text-sm text-gray-900 truncate max-w-[200px]">{file.name}</span>
+                  <button
+                    onClick={() => setFiles(prev => prev.filter((_, i) => i !== index))}
+                    aria-label={`Remove ${file.name}`}
+                    className="shrink-0 p-0.5 rounded-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+        <textarea
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={2}
+          className="flex-1 min-h-16 resize-none border-0 bg-transparent px-3 py-2 text-base text-gray-900 placeholder:text-gray-500 focus:outline-none disabled:opacity-50"
+        />
+        {showUpload && (
+          <div className="px-1">
+            <button
+              onClick={handleUploadClick}
+              disabled={disabled}
+              aria-label="Attach file"
+              className="shrink-0 p-2 rounded-md text-gray-700 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <Paperclip size={18} />
+            </button>
+          </div>
+        )}
+      </div>
+      <button
+        onClick={handleSubmit}
+        disabled={disabled || !value.trim()}
+        aria-label="Send message"
+        className="shrink-0 p-2 rounded-md text-gray-500 enabled:text-blue-500 enabled:hover:bg-blue-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <Send size={18} />
+      </button>
+    </div>
+  )
+}

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { useState } from 'react'
-import { Send, Paperclip, X, FileText, FileImage, FileVideo, File } from 'lucide-react'
+import { X, FileText, FileImage, FileVideo, File } from 'lucide-react'
 import { mergeClasses } from '../../utils/classNames'
+import { ButtonWidget } from '../Button/ButtonWidget'
+import { ParagraphField } from '../ParagraphField/ParagraphField'
 
 export interface ChatInputFile {
   name: string
@@ -18,7 +20,7 @@ export interface ChatInputProps {
   /** Value of the input (controlled) */
   value?: string
   /** Callback when value changes (controlled) */
-  onChange?: (value: string) => void
+  saveInto?: (value: string) => void
   /** Whether to show the upload/attach button */
   showUpload?: boolean
   /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
@@ -47,7 +49,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   onSubmit,
   disabled = false,
   value: controlledValue,
-  onChange,
+  saveInto,
   showUpload = false,
   className,
 }) => {
@@ -56,15 +58,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
   const isControlled = controlledValue !== undefined
   const value = isControlled ? controlledValue : internalValue
-
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = e.target.value
-    if (isControlled) {
-      onChange?.(newValue)
-    } else {
-      setInternalValue(newValue)
-    }
-  }
 
   const handleSubmit = () => {
     if (value.trim() && onSubmit) {
@@ -97,20 +90,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     input.click()
   }
 
-  const sailClasses = 'flex items-end gap-2 pr-1 pb-1 border border-gray-300 rounded-md focus-within:border-blue-500 transition-colors'
+  const sailClasses = 'border border-gray-300 rounded-sm focus-within:border-blue-500 transition-colors'
 
   return (
     <div className={mergeClasses(sailClasses, className)}>
       <div className="flex flex-col flex-1">
         {files.length > 0 && (
-          <div className="flex flex-col gap-1 px-3 pt-2">
+          <div className="flex flex-col gap-1 px-3 pt-3">
             {files.map((file, index) => {
               const IconComponent = getFileIcon(file.type)
               const iconColor = getFileIconColor(file.type)
               return (
                 <div
                   key={index}
-                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-gray-200 bg-white w-fit max-w-full"
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-sm border border-gray-200 bg-white w-fit max-w-full"
                 >
                   <IconComponent size={16} className={`shrink-0 ${iconColor}`} />
                   <span className="text-sm text-gray-900 truncate max-w-[200px]">{file.name}</span>
@@ -126,36 +119,51 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             })}
           </div>
         )}
-        <textarea
+        <ParagraphField
           value={value}
-          onChange={handleChange}
+          saveInto={(v) => {
+            if (isControlled) {
+              saveInto?.(v)
+            } else {
+              setInternalValue(v)
+            }
+          }}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={disabled}
-          rows={2}
-          className="flex-1 min-h-16 resize-none border-0 bg-transparent px-3 py-2 text-base text-gray-900 placeholder:text-gray-500 focus:outline-none disabled:opacity-50"
+          borderless
+          height="SHORT"
+          labelPosition="COLLAPSED"
+          label={placeholder}
+          marginBelow="NONE"
+          marginAbove="NONE"
+          className="flex-1 min-h-16"
         />
-        {showUpload && (
-          <div className="px-1">
-            <button
-              onClick={handleUploadClick}
-              disabled={disabled}
-              aria-label="Attach file"
-              className="shrink-0 p-2 rounded-md text-gray-700 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              <Paperclip size={18} />
-            </button>
+        <div className="flex items-center justify-between px-1 pb-1">
+          <div>
+            {showUpload && (
+              <ButtonWidget
+                icon="plus"
+                style="GHOST"
+                color="SECONDARY"
+                size="SMALL"
+                disabled={disabled}
+                accessibilityText="Attach file"
+                onClick={handleUploadClick}
+              />
+            )}
           </div>
-        )}
+          <ButtonWidget
+            icon="send"
+            style="GHOST"
+            color="ACCENT"
+            size="SMALL"
+            disabled={disabled || !value.trim()}
+            accessibilityText="Send message"
+            onClick={handleSubmit}
+          />
+        </div>
       </div>
-      <button
-        onClick={handleSubmit}
-        disabled={disabled || !value.trim()}
-        aria-label="Send message"
-        className="shrink-0 p-2 rounded-md text-gray-500 enabled:text-blue-500 enabled:hover:bg-blue-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-      >
-        <Send size={18} />
-      </button>
     </div>
   )
 }

--- a/src/components/Chat/ChatPanel.stories.tsx
+++ b/src/components/Chat/ChatPanel.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Settings, MoreVertical, X } from 'lucide-react'
+import { ChatPanel } from './ChatPanel'
+import { ChatInput } from './ChatInput'
+
+const meta = {
+  title: 'Components/Chat/ChatPanel',
+  component: ChatPanel,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof ChatPanel>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: 'Chat',
+    children: (
+      <div className="space-y-4">
+        <div className="bg-blue-50 rounded-md px-4 py-2 ml-auto max-w-[80%] w-fit text-gray-900">Hello!</div>
+        <div className="text-gray-900">Hi there! How can I help you today?</div>
+      </div>
+    ),
+    footer: <ChatInput />,
+  },
+}
+
+export const WithHeaderActions: Story = {
+  args: {
+    title: 'Chat Assistant',
+    headerActions: [
+      { icon: <Settings size={18} />, label: 'Settings', onClick: () => console.log('Settings') },
+      { icon: <MoreVertical size={18} />, label: 'More options', onClick: () => console.log('More') },
+      { icon: <X size={18} />, label: 'Close', onClick: () => console.log('Close') },
+    ],
+    children: (
+      <div className="space-y-4">
+        <div className="bg-blue-50 rounded-md px-4 py-2 ml-auto max-w-[80%] w-fit text-gray-900">Hello!</div>
+        <div className="text-gray-900">Hi there! How can I help you today?</div>
+      </div>
+    ),
+    footer: <ChatInput placeholder="Ask me anything..." />,
+  },
+}
+
+export const LongScrollingContent: Story = {
+  args: {
+    title: 'Long Conversation',
+    children: (
+      <div className="space-y-4">
+        {Array.from({ length: 20 }, (_, i) => (
+          <div key={i} className="space-y-4">
+            <div className="bg-blue-50 rounded-md px-4 py-2 ml-auto max-w-[80%] w-fit text-gray-900">
+              Message {i + 1}: This is a test message
+            </div>
+            <div className="text-gray-900">
+              Response {i + 1}: This is a response to your message with additional content to demonstrate scrolling.
+            </div>
+          </div>
+        ))}
+      </div>
+    ),
+    footer: <ChatInput />,
+    height: '600px',
+  },
+}
+
+export const NoFooter: Story = {
+  args: {
+    title: 'Read-only Chat',
+    children: (
+      <div className="space-y-4">
+        <div className="bg-blue-50 rounded-md px-4 py-2 ml-auto max-w-[80%] w-fit text-gray-900">Hello!</div>
+        <div className="text-gray-900">Hi there! This is a read-only chat view.</div>
+      </div>
+    ),
+  },
+}
+
+export const NoHeader: Story = {
+  args: {
+    children: (
+      <div className="space-y-4">
+        <div className="bg-blue-50 rounded-md px-4 py-2 ml-auto max-w-[80%] w-fit text-gray-900">Hello!</div>
+        <div className="text-gray-900">Hi there! This chat has no header.</div>
+      </div>
+    ),
+    footer: <ChatInput />,
+  },
+}

--- a/src/components/Chat/ChatPanel.stories.tsx
+++ b/src/components/Chat/ChatPanel.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { Settings, MoreVertical, X } from 'lucide-react'
 import { ChatPanel } from './ChatPanel'
 import { ChatInput } from './ChatInput'
 
@@ -30,9 +29,9 @@ export const WithHeaderActions: Story = {
   args: {
     title: 'Chat Assistant',
     headerActions: [
-      { icon: <Settings size={18} />, label: 'Settings', onClick: () => console.log('Settings') },
-      { icon: <MoreVertical size={18} />, label: 'More options', onClick: () => console.log('More') },
-      { icon: <X size={18} />, label: 'Close', onClick: () => console.log('Close') },
+      { icon: 'settings', label: 'Settings', onClick: () => console.log('Settings') },
+      { icon: 'more-vertical', label: 'More options', onClick: () => console.log('More') },
+      { icon: 'x', label: 'Close', onClick: () => console.log('Close') },
     ],
     children: (
       <div className="space-y-4">
@@ -62,7 +61,7 @@ export const LongScrollingContent: Story = {
       </div>
     ),
     footer: <ChatInput />,
-    height: '600px',
+    height: 'TALL',
   },
 }
 

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import type { ReactNode } from 'react'
+import { mergeClasses } from '../../utils/classNames'
+
+export interface ChatPanelHeaderAction {
+  icon: ReactNode
+  label: string
+  onClick?: () => void
+}
+
+export interface ChatPanelProps {
+  /** Title displayed in the header */
+  title?: string
+  /** Action buttons displayed in the header */
+  headerActions?: ChatPanelHeaderAction[]
+  /** Content to display in the scrollable area */
+  children: ReactNode
+  /** Content to display in the footer (typically ChatInput) */
+  footer?: ReactNode
+  /** Height of the panel (defaults to full viewport height) */
+  height?: string
+  /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
+  className?: string
+}
+
+export const ChatPanel: React.FC<ChatPanelProps> = ({
+  title,
+  headerActions,
+  children,
+  footer,
+  height = '100vh',
+  className,
+}) => {
+  const sailClasses = 'flex flex-col bg-white'
+
+  return (
+    <div className={mergeClasses(sailClasses, className)} style={{ height }}>
+      {(title || headerActions) && (
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 shrink-0">
+          {title && <h2 className="text-lg font-semibold text-gray-900">{title}</h2>}
+          {headerActions && headerActions.length > 0 && (
+            <div className="flex items-center gap-1" role="group" aria-label="Header actions">
+              {headerActions.map((action, index) => (
+                <button
+                  key={index}
+                  onClick={action.onClick}
+                  aria-label={action.label}
+                  className="p-1.5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                >
+                  {action.icon}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div
+        className="flex-1 overflow-y-auto"
+        tabIndex={0}
+        role="region"
+        aria-label="Chat messages"
+      >
+        <div className="px-4 py-4 text-base">{children}</div>
+      </div>
+
+      {footer && (
+        <div className="px-4 py-3 border-t border-gray-200 shrink-0">{footer}</div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import type { ReactNode } from 'react'
+import type { SAILGridHeight } from '../../types/sail'
 import { mergeClasses } from '../../utils/classNames'
+import { ButtonWidget } from '../Button/ButtonWidget'
 
 export interface ChatPanelHeaderAction {
-  icon: ReactNode
+  icon: string
   label: string
   onClick?: () => void
 }
@@ -17,8 +19,8 @@ export interface ChatPanelProps {
   children: ReactNode
   /** Content to display in the footer (typically ChatInput) */
   footer?: ReactNode
-  /** Height of the panel (defaults to full viewport height) */
-  height?: string
+  /** Height of the panel */
+  height?: SAILGridHeight
   /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
   className?: string
 }
@@ -28,27 +30,39 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   headerActions,
   children,
   footer,
-  height = '100vh',
+  height = 'AUTO',
   className,
 }) => {
-  const sailClasses = 'flex flex-col bg-white'
+  const heightMap: Record<SAILGridHeight, string> = {
+    SHORT: 'h-40',
+    SHORT_PLUS: 'h-52',
+    MEDIUM: 'h-64',
+    MEDIUM_PLUS: 'h-80',
+    TALL: 'h-96',
+    TALL_PLUS: 'h-[28rem]',
+    EXTRA_TALL: 'h-[36rem]',
+    AUTO: 'h-screen',
+  }
+
+  const sailClasses = `flex flex-col bg-white ${heightMap[height]}`
 
   return (
-    <div className={mergeClasses(sailClasses, className)} style={{ height }}>
+    <div className={mergeClasses(sailClasses, className)}>
       {(title || headerActions) && (
         <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 shrink-0">
           {title && <h2 className="text-lg font-semibold text-gray-900">{title}</h2>}
           {headerActions && headerActions.length > 0 && (
             <div className="flex items-center gap-1" role="group" aria-label="Header actions">
               {headerActions.map((action, index) => (
-                <button
+                <ButtonWidget
                   key={index}
+                  icon={action.icon}
+                  style="GHOST"
+                  color="SECONDARY"
+                  size="SMALL"
+                  accessibilityText={action.label}
                   onClick={action.onClick}
-                  aria-label={action.label}
-                  className="p-1.5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                >
-                  {action.icon}
-                </button>
+                />
               ))}
             </div>
           )}

--- a/src/components/Chat/index.ts
+++ b/src/components/Chat/index.ts
@@ -1,0 +1,11 @@
+export { ChatInput } from './ChatInput'
+export type { ChatInputProps, ChatInputFile } from './ChatInput'
+
+export { ChatPanel } from './ChatPanel'
+export type { ChatPanelProps, ChatPanelHeaderAction } from './ChatPanel'
+
+export { ChatConfirmation } from './ChatConfirmation'
+export type { ChatConfirmationProps } from './ChatConfirmation'
+
+export { ChatFeedback } from './ChatFeedback'
+export type { ChatFeedbackProps, FeedbackOption, FeedbackOptions, FeedbackDetails } from './ChatFeedback'

--- a/src/components/ParagraphField/ParagraphField.tsx
+++ b/src/components/ParagraphField/ParagraphField.tsx
@@ -110,8 +110,9 @@ export const ParagraphField: React.FC<ParagraphFieldProps> = ({
   }
 
   const inputClasses = [
-    'w-full text-base resize-y',
+    'w-full text-base',
     heightMap[height],
+    !borderless && 'resize-y',
     !borderless && 'px-3 py-2 border border-gray-300 rounded-sm bg-white',
     !borderless && 'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
     borderless && 'px-3 py-2 border-0 bg-transparent resize-none focus:outline-none',

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -75,3 +75,6 @@ export * from './SiteNav'
 
 // RecordView template
 export * from './RecordView'
+
+// Chat components
+export * from './Chat'


### PR DESCRIPTION
Migrate 4 chat components (ChatConfirmation, ChatFeedback, ChatInput, ChatPanel) with the following UX polishes:

ChatConfirmation:
- Restyled secondary action style
- Added completed state

ChatFeedback:
- Refactor to use CheckboxField and ButtonWidget
- Change Agent Evaluation variant colors to use .50 background instead of .100

ChatInput:
- Border change to gray-300
- Send button: gray icon → blue-500 when active, blue-50 bg on hover, hover disabled when inactive
- Add Upload: Added showUpload prop with Paperclip icon (bottom-left, gray-700, rounded-md)
- File chips: Dynamic file attachment system — files appear as stacked chips above the textarea with type-colored icons, truncated names, and X to remove.

ChatPanel:
- Fix text size (explicit token instead of browser default)

Partially addresses https://github.com/pglevy/sailwind/issues/77