### PR TITLE
fix: use focus-visible for ring styles

### DIFF
--- a/src/components/Button/ButtonWidget.tsx
+++ b/src/components/Button/ButtonWidget.tsx
@@ -243,7 +243,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   const sailClasses = [
     'inline-flex items-center justify-center gap-1',
     'font-medium transition-colors h-auto rounded-sm',
-    'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
     effectiveSizeClasses,
     widthClass,
     getBorderClasses(),

--- a/src/components/Checkbox/CheckboxField.tsx
+++ b/src/components/Checkbox/CheckboxField.tsx
@@ -194,7 +194,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
                   isChecked
                     ? 'border-blue-500 bg-blue-500'
                     : 'border-gray-400 bg-white',
-                  'focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:ring-offset-1',
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:ring-offset-1',
                   'transition-all duration-150 ease-in',
                   disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
                 ].filter(Boolean).join(' ')}

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -20,7 +20,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 // Shared button classes matching ButtonWidget styles
-const btnBase = 'inline-flex items-center justify-center font-medium rounded-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer'
+const btnBase = 'inline-flex items-center justify-center font-medium rounded-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 cursor-pointer'
 const btnSolid = `${btnBase} px-4 py-3 text-base leading-none border border-transparent`
 const btnOutline = `${btnBase} px-4 py-3 text-base leading-none border`
 const btnSmOutline = `${btnBase} px-3 py-2 text-sm leading-none border`

--- a/src/components/Dialog/DialogField.tsx
+++ b/src/components/Dialog/DialogField.tsx
@@ -148,7 +148,7 @@ export const DialogField: React.FC<DialogFieldProps> = ({
           'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
           'data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]',
           'data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
-          'focus:outline-none'
+          'focus-visible:outline-none'
         ].filter(Boolean).join(' ')}
         onPointerDownOutside={closeOnOutsideClick ? undefined : (e) => e.preventDefault()}
         onEscapeKeyDown={closeOnEscape ? undefined : (e) => e.preventDefault()}
@@ -172,7 +172,7 @@ export const DialogField: React.FC<DialogFieldProps> = ({
               {showCloseButton && (
                 <Dialog.Close asChild>
                   <button
-                    className="ml-4 p-1 rounded-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="ml-4 p-1 rounded-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     aria-label="Close dialog"
                   >
                     <X className="h-4 w-4" />

--- a/src/components/Dropdown/DropdownFieldBase.tsx
+++ b/src/components/Dropdown/DropdownFieldBase.tsx
@@ -202,7 +202,7 @@ export const DropdownFieldBase: React.FC<DropdownFieldBaseProps> = ({
           'text-base text-left',
           disabled ? 'opacity-50 cursor-not-allowed bg-gray-50' : 'cursor-pointer hover:border-gray-500',
           showValidations && 'border-red-700',
-          'focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500'
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:border-blue-500'
         ].filter(Boolean).join(' ')}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
@@ -245,7 +245,7 @@ export const DropdownFieldBase: React.FC<DropdownFieldBaseProps> = ({
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   placeholder="Search..."
-                  className="w-full pl-8 pr-3 py-1.5 border border-gray-300 rounded-sm text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  className="w-full pl-8 pr-3 py-1.5 border border-gray-300 rounded-sm text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:border-blue-500"
                 />
               </div>
             </div>
@@ -272,7 +272,7 @@ export const DropdownFieldBase: React.FC<DropdownFieldBaseProps> = ({
                       'w-full px-3 py-2 text-left text-base',
                       'hover:bg-gray-100',
                       isSelected && 'bg-blue-50 text-blue-700 font-medium',
-                      'focus:outline-none focus:bg-gray-100'
+                      'focus-visible:outline-none focus-visible:bg-gray-100'
                     ].filter(Boolean).join(' ')}
                   >
                     {multiple && (

--- a/src/components/Heading/HeadingField.tsx
+++ b/src/components/Heading/HeadingField.tsx
@@ -169,7 +169,7 @@ export const HeadingField: React.FC<HeadingFieldProps> = ({
       <HeadingElement {...headingProps}>
         <button
           onClick={link}
-          className="text-inherit border-b-2 border-blue-500/0 hover:border-blue-500 hover:cursor-pointer focus:outline-none focus:ring-1 focus:ring-blue-500 focus:ring-offset-2 transition-all ease-in-out"
+          className="text-inherit border-b-2 border-blue-500/0 hover:border-blue-500 hover:cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-all ease-in-out"
         >
           {text}
         </button>

--- a/src/components/MessageBanner/MessageBanner.tsx
+++ b/src/components/MessageBanner/MessageBanner.tsx
@@ -219,7 +219,7 @@ export const MessageBanner: React.FC<MessageBannerProps> = ({
           <button
             type="button"
             onClick={onClose}
-            className="flex-shrink-0 p-1 rounded-sm hover:bg-black/10 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
+            className="flex-shrink-0 p-1 rounded-sm hover:bg-black/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
             aria-label="Close banner"
           >
             <X className="w-4 h-4" aria-hidden="true" />

--- a/src/components/MessageBanner/MessageBanner.tsx
+++ b/src/components/MessageBanner/MessageBanner.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Info, CheckCircle, AlertCircle, AlertTriangle, X } from 'lucide-react'
 import type { SAILShape, SAILMarginSize, SAILAlign } from '../../types/sail'
 import type { ButtonWidgetProps } from '../Button/ButtonWidget'
+import { ButtonWidget } from '../Button/ButtonWidget'
 import { ButtonArrayLayout } from '../Button/ButtonArrayLayout'
 import { mergeClasses } from '../../utils/classNames'
 
@@ -216,14 +217,14 @@ export const MessageBanner: React.FC<MessageBannerProps> = ({
 
         {/* Close button */}
         {showCloseButton && (
-          <button
-            type="button"
+          <ButtonWidget
+            style="GHOST"
+            size="SMALL"
+            icon={X}
+            accessibilityText="Close banner"
+            marginBelow="NONE"
             onClick={onClose}
-            className="flex-shrink-0 p-1 rounded-sm hover:bg-black/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-            aria-label="Close banner"
-          >
-            <X className="w-4 h-4" aria-hidden="true" />
-          </button>
+          />
         )}
       </div>
 

--- a/src/components/RadioButton/RadioButtonField.tsx
+++ b/src/components/RadioButton/RadioButtonField.tsx
@@ -177,7 +177,7 @@ export const RadioButtonField: React.FC<RadioButtonFieldProps> = ({
                 isChecked
                   ? 'border-blue-500 bg-blue-500'
                   : 'border-gray-400 bg-white',
-                'focus:outline-none focus:ring-1 focus:ring-blue-500 focus:ring-offset-1',
+                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:ring-offset-1',
                 'transition-colors duration-150 ease-in-out',
                 'checked:bg-[url("data:image/svg+xml;charset=utf-8;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTYgMTYiIGZpbGw9IndoaXRlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxjaXJjbGUgY3g9IjgiIGN5PSI4IiByPSI0Ii8+PC9zdmc+")] checked:bg-center checked:bg-no-repeat checked:bg-[length:10px_10px]',
                 disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'

--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
@@ -363,7 +363,7 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
                   allPageRowsSelected
                     ? 'border-blue-500 bg-blue-500'
                     : 'border-gray-400 bg-white',
-                  'focus:outline-none focus:ring-1 focus:ring-blue-500 focus:ring-offset-1',
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:ring-offset-1',
                   'transition-colors duration-150 ease-in-out cursor-pointer',
                   'checked:bg-[url("data:image/svg+xml;charset=utf-8;base64,IDxzdmcgd2lkdGg9IjE3OTIiIGhlaWdodD0iMTc5MiIgdmlld0JveD0iMCAwIDE3OTIgMTc5MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTY3MSA1NjZxMCA0MC0yOCA2OGwtNzI0IDcyNC0xMzYgMTM2cS0yOCAyOC02OCAyOHQtNjgtMjhsLTEzNi0xMzYtMzYyLTM2MnEtMjgtMjgtMjgtNjh0MjgtNjhsMTM2LTEzNnEyOC0yOCA2OC0yOHQ2OCAyOGwyOTQgMjk1IDY1Ni02NTdxMjgtMjggNjgtMjh0NjggMjhsMTM2IDEzNnEyOCAyOCAyOCA2OHoiIGZpbGw9IndoaXRlIi8+PC9zdmc+")] checked:bg-center checked:bg-no-repeat checked:bg-[length:10px_10px]',
                 ].join(' ')}
@@ -446,7 +446,7 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
                       isRowSelected
                         ? 'border-blue-500 bg-blue-500'
                         : 'border-gray-400 bg-white',
-                      'focus:outline-none focus:ring-1 focus:ring-blue-500 focus:ring-offset-1',
+                      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:ring-offset-1',
                       'transition-colors duration-150 ease-in-out cursor-pointer',
                       'checked:bg-[url("data:image/svg+xml;charset=utf-8;base64,IDxzdmcgd2lkdGg9IjE3OTIiIGhlaWdodD0iMTc5MiIgdmlld0JveD0iMCAwIDE3OTIgMTc5MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTY3MSA1NjZxMCA0MC0yOCA2OGwtNzI0IDcyNC0xMzYgMTM2cS0yOCAyOC02OCAyOHQtNjgtMjhsLTEzNi0xMzYtMzYyLTM2MnEtMjgtMjgtMjgtNjh0MjgtNjhsMTM2LTEzNnEyOC0yOCA2OC0yOHQ2OCAyOGwyOTQgMjk1IDY1Ni02NTdxMjgtMjggNjgtMjh0NjggMjhsMTM2IDEzNnEyOCAyOCAyOCA2OHoiIGZpbGw9IndoaXRlIi8+PC9zdmc+")] checked:bg-center checked:bg-no-repeat checked:bg-[length:10px_10px]',
                     ].join(' ')}

--- a/src/components/Slider/SliderField.tsx
+++ b/src/components/Slider/SliderField.tsx
@@ -236,7 +236,7 @@ export const SliderField: React.FC<SliderFieldProps> = ({
               'block rounded-full transition-colors',
               sizeMap[size].thumb,
               colorClasses.thumb,
-              'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
               orientation === "VERTICAL" ? '' : ''
             ].join(' ')}
             style={color.startsWith('#') ? { backgroundColor: color } : undefined}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -156,11 +156,11 @@ export const TextField: React.FC<TextFieldProps> = ({
     readOnly && 'border-none bg-transparent p-0',
     // Normal mode: standard input styling
     !readOnly && 'px-3 py-2 border border-gray-300 rounded-sm bg-white',
-    !readOnly && 'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
+    !readOnly && 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:border-transparent',
     // Disabled state
     disabled && 'bg-gray-100 text-gray-700 cursor-not-allowed',
     // Error state
-    validations.length > 0 && 'border-red-700 focus:ring-red-700'
+    validations.length > 0 && 'border-red-700 focus-visible:ring-red-700'
   ].filter(Boolean).join(' ')
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Toggle/ToggleField.tsx
+++ b/src/components/Toggle/ToggleField.tsx
@@ -222,7 +222,7 @@ export const ToggleField: React.FC<ToggleFieldProps> = ({
       className={[
         'inline-flex items-center justify-center gap-1',
         'font-medium transition-colors h-auto rounded-sm',
-        'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
         sizeMap[size],
         getColorClasses(),
         disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'


### PR DESCRIPTION
Closes #90

- Replace `focus:ring` / `focus:outline-none` with `focus-visible:` equivalents across all components so the focus ring only appears on keyboard navigation, not on mouse/touch clicks.
- Also swapped out close button on `MessageBanner` with `ButtonWidget`