### PR TITLE
feat(ReadOnlyGrid): add new selectionStyle values and pagingControls (26.3)

### DIFF
--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.stories.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.stories.tsx
@@ -28,7 +28,8 @@ const meta = {
     borderStyle: { control: 'select', options: ['STANDARD', 'LIGHT'] },
     spacing: { control: 'select', options: ['STANDARD', 'DENSE'] },
     height: { control: 'select', options: ['SHORT', 'SHORT_PLUS', 'MEDIUM', 'MEDIUM_PLUS', 'TALL', 'TALL_PLUS', 'EXTRA_TALL', 'AUTO'] },
-    selectionStyle: { control: 'select', options: ['CHECKBOX', 'ROW_HIGHLIGHT'] },
+    selectionStyle: { control: 'select', options: ['CHECKBOX', 'ROW_HIGHLIGHT', 'CHECKBOX_SUBTLE_HIGHLIGHT', 'SUBTLE_HIGHLIGHT'] },
+    pagingControls: { control: 'select', options: ['STANDARD', 'ROW_COUNT'] },
     labelPosition: { control: 'select', options: ['ABOVE', 'ADJACENT', 'COLLAPSED', 'JUSTIFIED'] },
     marginAbove: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
     marginBelow: { control: 'select', options: ['NONE', 'EVEN_LESS', 'LESS', 'STANDARD', 'MORE', 'EVEN_MORE'] },
@@ -69,11 +70,29 @@ export const EmptyState: Story = {
   ),
 }
 
-/** 3. WithPaging — Full dataset with pageSize=5 showing paging controls */
-export const WithPaging: Story = {
+/** 3. WithPagingStandard — Default STANDARD paging ("of many", no first/last buttons) */
+export const WithPagingStandard: Story = {
   args: {
     data: employees,
     pageSize: 5,
+    pagingControls: 'STANDARD',
+  },
+  render: (args) => (
+    <ReadOnlyGrid {...args}>
+      <GridColumn label="Name" value="name" sortField="name" />
+      <GridColumn label="Department" value="department" sortField="department" />
+      <GridColumn label="Salary" value="salary" sortField="salary" />
+      <GridColumn label="Start Date" value="startDate" />
+    </ReadOnlyGrid>
+  ),
+}
+
+/** 4. WithPagingRowCount — ROW_COUNT paging (shows total count + first/last buttons) */
+export const WithPagingRowCount: Story = {
+  args: {
+    data: employees,
+    pageSize: 5,
+    pagingControls: 'ROW_COUNT',
   },
   render: (args) => (
     <ReadOnlyGrid {...args}>
@@ -85,17 +104,14 @@ export const WithPaging: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    // Verify grid renders with data
     await expect(canvas.getByText('Alice Johnson')).toBeVisible()
-    // Navigate to next page
     const nextButton = canvas.getByRole('button', { name: /next page/i })
     await userEvent.click(nextButton)
-    // First page data should no longer be visible, second page data should appear
     await expect(canvas.getByText('Frank Miller')).toBeVisible()
   },
 }
 
-/** 4. WithSorting — Sortable columns with initial sort on salary descending */
+/** 5. WithSorting — Sortable columns with initial sort on salary descending */
 export const WithSorting: Story = {
   args: {
     data: employees,
@@ -112,7 +128,7 @@ export const WithSorting: Story = {
   ),
 }
 
-/** 5. WithCheckboxSelection — Selectable grid with checkbox style */
+/** 6. WithCheckboxSelection — CHECKBOX selection style (default) */
 export const WithCheckboxSelection: Story = {
   args: {
     data: employees.slice(0, 6),
@@ -131,7 +147,45 @@ export const WithCheckboxSelection: Story = {
   },
 }
 
-/** 6. WithRowHighlightSelection — ROW_HIGHLIGHT selection style */
+/** 7. WithCheckboxSubtleHighlightSelection — CHECKBOX_SUBTLE_HIGHLIGHT selection style (26.3) */
+export const WithCheckboxSubtleHighlightSelection: Story = {
+  args: {
+    data: employees.slice(0, 6),
+    selectable: true,
+    selectionStyle: 'CHECKBOX_SUBTLE_HIGHLIGHT',
+  },
+  render: (args) => {
+    const [selected, setSelected] = React.useState<(string | number)[]>([1, 3])
+    return (
+      <ReadOnlyGrid {...args} selectionValue={selected} selectionSaveInto={setSelected}>
+        <GridColumn label="Name" value="name" />
+        <GridColumn label="Department" value="department" />
+        <GridColumn label="Salary" value="salary" />
+      </ReadOnlyGrid>
+    )
+  },
+}
+
+/** 8. WithSubtleHighlightSelection — SUBTLE_HIGHLIGHT selection style (26.3) */
+export const WithSubtleHighlightSelection: Story = {
+  args: {
+    data: employees.slice(0, 6),
+    selectable: true,
+    selectionStyle: 'SUBTLE_HIGHLIGHT',
+  },
+  render: (args) => {
+    const [selected, setSelected] = React.useState<(string | number)[]>([2, 4])
+    return (
+      <ReadOnlyGrid {...args} selectionValue={selected} selectionSaveInto={setSelected}>
+        <GridColumn label="Name" value="name" />
+        <GridColumn label="Department" value="department" />
+        <GridColumn label="Salary" value="salary" />
+      </ReadOnlyGrid>
+    )
+  },
+}
+
+/** 9. WithRowHighlightSelection — ROW_HIGHLIGHT selection style */
 export const WithRowHighlightSelection: Story = {
   args: {
     data: employees.slice(0, 6),
@@ -150,7 +204,7 @@ export const WithRowHighlightSelection: Story = {
   },
 }
 
-/** 7. StyledGrid — borderStyle, shadeAlternateRows, dense spacing */
+/** 10. StyledGrid — borderStyle, shadeAlternateRows, dense spacing */
 export const StyledGrid: Story = {
   args: {
     data: employees.slice(0, 8),
@@ -168,7 +222,7 @@ export const StyledGrid: Story = {
   ),
 }
 
-/** 8. FixedHeight — MEDIUM height to show scrolling behavior */
+/** 11. FixedHeight — MEDIUM height to show scrolling behavior */
 export const FixedHeight: Story = {
   args: {
     data: employees,
@@ -184,7 +238,7 @@ export const FixedHeight: Story = {
   ),
 }
 
-/** 9. WithLabelAndValidations — label, instructions, validations, helpTooltip */
+/** 12. WithLabelAndValidations — label, instructions, validations, helpTooltip */
 export const WithLabelAndValidations: Story = {
   args: {
     label: 'Employee Directory',
@@ -202,7 +256,7 @@ export const WithLabelAndValidations: Story = {
   ),
 }
 
-/** 10. ColumnWidthsAndAlignment — Various column widths and alignments */
+/** 13. ColumnWidthsAndAlignment — Various column widths and alignments */
 export const ColumnWidthsAndAlignment: Story = {
   args: {
     data: employees.slice(0, 5),
@@ -217,7 +271,7 @@ export const ColumnWidthsAndAlignment: Story = {
   ),
 }
 
-/** 11. ComputedColumns — Using function value accessors for computed columns */
+/** 14. ComputedColumns — Using function value accessors for computed columns */
 export const ComputedColumns: Story = {
   args: {
     data: employees.slice(0, 6),
@@ -227,7 +281,7 @@ export const ComputedColumns: Story = {
       <GridColumn label="Name" value="name" />
       <GridColumn
         label="Formatted Salary"
-        value={(row: any) => `$${row.salary.toLocaleString()}`}
+        value={(row: any) => `${row.salary.toLocaleString()}`}
         align="END"
       />
       <GridColumn

--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.stories.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.stories.tsx
@@ -193,7 +193,7 @@ export const WithRowHighlightSelection: Story = {
     selectionStyle: 'ROW_HIGHLIGHT',
   },
   render: (args) => {
-    const [selected, setSelected] = React.useState<(string | number)[]>([])
+    const [selected, setSelected] = React.useState<(string | number)[]>([2, 4])
     return (
       <ReadOnlyGrid {...args} selectionValue={selected} selectionSaveInto={setSelected}>
         <GridColumn label="Name" value="name" />

--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.test.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.test.tsx
@@ -215,7 +215,7 @@ function expectRangeText(start: number, end: number, total: number) {
 describe("ReadOnlyGrid - paging", () => {
   it("shows paging controls when data exceeds pageSize", () => {
     render(
-      <ReadOnlyGrid data={generateData(15)} pageSize={5}>
+      <ReadOnlyGrid data={generateData(15)} pageSize={5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -241,7 +241,7 @@ describe("ReadOnlyGrid - paging", () => {
   it("navigates to next page and back", async () => {
     const user = userEvent.setup();
     render(
-      <ReadOnlyGrid data={generateData(12)} pageSize={5}>
+      <ReadOnlyGrid data={generateData(12)} pageSize={5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -265,7 +265,7 @@ describe("ReadOnlyGrid - paging", () => {
 
   it("disables first/previous buttons on first page and last/next on last page", () => {
     render(
-      <ReadOnlyGrid data={generateData(15)} pageSize={5}>
+      <ReadOnlyGrid data={generateData(15)} pageSize={5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -279,14 +279,14 @@ describe("ReadOnlyGrid - paging", () => {
   it("disables next/last buttons on last page", async () => {
     const user = userEvent.setup();
     render(
-      <ReadOnlyGrid data={generateData(8)} pageSize={5}>
+      <ReadOnlyGrid data={generateData(13)} pageSize={5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
 
-    // Navigate to last page (page 2)
-    await user.click(screen.getByRole("button", { name: "Next page" }));
-    expectRangeText(6, 8, 8);
+    // Navigate to last page (page 3)
+    await user.click(screen.getByRole("button", { name: "Last page" }));
+    expectRangeText(11, 13, 13);
     expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Last page" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Previous page" })).toBeEnabled();
@@ -296,7 +296,7 @@ describe("ReadOnlyGrid - paging", () => {
   it("first page button jumps to page 1, last page button jumps to final page", async () => {
     const user = userEvent.setup();
     render(
-      <ReadOnlyGrid data={generateData(25)} pageSize={5}>
+      <ReadOnlyGrid data={generateData(25)} pageSize={5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -314,7 +314,7 @@ describe("ReadOnlyGrid - paging", () => {
 
   it("defaults pageSize to 10", () => {
     render(
-      <ReadOnlyGrid data={generateData(15)}>
+      <ReadOnlyGrid data={generateData(15)} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -328,7 +328,7 @@ describe("ReadOnlyGrid - paging", () => {
   it("shows correct page range text", async () => {
     const user = userEvent.setup();
     render(
-      <ReadOnlyGrid data={generateData(23)} pageSize={10}>
+      <ReadOnlyGrid data={generateData(23)} pageSize={10} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -344,7 +344,7 @@ describe("ReadOnlyGrid - paging", () => {
 
   it("handles invalid pageSize by defaulting to 10", () => {
     render(
-      <ReadOnlyGrid data={generateData(15)} pageSize={0}>
+      <ReadOnlyGrid data={generateData(15)} pageSize={0} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -354,7 +354,7 @@ describe("ReadOnlyGrid - paging", () => {
 
   it("handles negative pageSize by defaulting to 10", () => {
     render(
-      <ReadOnlyGrid data={generateData(15)} pageSize={-5}>
+      <ReadOnlyGrid data={generateData(15)} pageSize={-5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -364,7 +364,7 @@ describe("ReadOnlyGrid - paging", () => {
 
   it("paging buttons have tooltips", () => {
     render(
-      <ReadOnlyGrid data={generateData(15)} pageSize={5}>
+      <ReadOnlyGrid data={generateData(15)} pageSize={5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" />
       </ReadOnlyGrid>
     );
@@ -488,7 +488,7 @@ describe("ReadOnlyGrid - sorting", () => {
     }));
 
     render(
-      <ReadOnlyGrid data={data} pageSize={5}>
+      <ReadOnlyGrid data={data} pageSize={5} pagingControls="ROW_COUNT">
         <GridColumn label="Name" value="name" sortField="name" />
       </ReadOnlyGrid>
     );
@@ -652,10 +652,10 @@ describe("ReadOnlyGrid - selection", () => {
     expect(rows[2]).toHaveClass("cursor-pointer");
     expect(rows[3]).toHaveClass("cursor-pointer");
 
-    // Only Bob's row (id=2) should be highlighted
-    expect(rows[1]).not.toHaveClass("bg-blue-50");
-    expect(rows[2]).toHaveClass("bg-blue-50");
-    expect(rows[3]).not.toHaveClass("bg-blue-50");
+    // Only Bob's row (id=2) should be highlighted with solid blue
+    expect(rows[1]).not.toHaveClass("bg-blue-500");
+    expect(rows[2]).toHaveClass("bg-blue-500");
+    expect(rows[3]).not.toHaveClass("bg-blue-500");
   });
 
   it("ROW_HIGHLIGHT clicking row toggles selection", async () => {

--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
@@ -417,7 +417,7 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
           const isCheckboxSubtleHighlightSelected =
             selectable && selectionStyle === "CHECKBOX_SUBTLE_HIGHLIGHT" && isRowSelected;
           const isClickableRow =
-            selectable && (selectionStyle === "ROW_HIGHLIGHT" || selectionStyle === "SUBTLE_HIGHLIGHT");
+            selectable && (selectionStyle === "ROW_HIGHLIGHT" || selectionStyle === "SUBTLE_HIGHLIGHT" || selectionStyle === "CHECKBOX_SUBTLE_HIGHLIGHT");
           const alternateRowClass =
             shadeAlternateRows && rowIndex % 2 === 0 && !isRowHighlightSelected && !isSubtleHighlightSelected && !isCheckboxSubtleHighlightSelected
               ? "bg-gray-50"

--- a/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
+++ b/src/components/ReadOnlyGrid/ReadOnlyGrid.tsx
@@ -33,7 +33,7 @@ export interface ReadOnlyGridProps {
   /** Whether rows are selectable */
   selectable?: boolean;
   /** Selection visual style */
-  selectionStyle?: "CHECKBOX" | "ROW_HIGHLIGHT";
+  selectionStyle?: "CHECKBOX" | "ROW_HIGHLIGHT" | "CHECKBOX_SUBTLE_HIGHLIGHT" | "SUBTLE_HIGHLIGHT";
   /** Currently selected row identifiers */
   selectionValue?: (string | number)[];
   /** Callback when selection changes */
@@ -58,6 +58,8 @@ export interface ReadOnlyGridProps {
   marginAbove?: SAILMarginSize;
   /** Space below component */
   marginBelow?: SAILMarginSize;
+  /** Determines if the paging includes the total row count. "STANDARD" hides total count for performance; "ROW_COUNT" shows total count and first/last controls. */
+  pagingControls?: "STANDARD" | "ROW_COUNT";
   /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
   className?: string;
 }
@@ -180,6 +182,7 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
   shadeAlternateRows = false,
   spacing = "STANDARD",
   height = "AUTO",
+  pagingControls = "STANDARD",
   accessibilityText,
   marginAbove,
   marginBelow,
@@ -346,7 +349,7 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
     >
       <thead className={needsScrollContainer ? "sticky top-0 bg-white z-10" : undefined}>
         <tr className={headerRowBorderClass}>
-          {selectable && selectionStyle === "CHECKBOX" && (
+          {selectable && (selectionStyle === "CHECKBOX" || selectionStyle === "CHECKBOX_SUBTLE_HIGHLIGHT") && (
             <th className={`${cellPaddingClass} w-10 align-middle text-center${colDividerClass ? ` ${colDividerClass}` : ""}`}>
               <input
                 type="checkbox"
@@ -409,27 +412,31 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
           const isRowSelected = selectable && selectionValue.includes(rowId);
           const isRowHighlightSelected =
             selectable && selectionStyle === "ROW_HIGHLIGHT" && isRowSelected;
+          const isSubtleHighlightSelected =
+            selectable && selectionStyle === "SUBTLE_HIGHLIGHT" && isRowSelected;
+          const isCheckboxSubtleHighlightSelected =
+            selectable && selectionStyle === "CHECKBOX_SUBTLE_HIGHLIGHT" && isRowSelected;
+          const isClickableRow =
+            selectable && (selectionStyle === "ROW_HIGHLIGHT" || selectionStyle === "SUBTLE_HIGHLIGHT");
           const alternateRowClass =
-            shadeAlternateRows && rowIndex % 2 === 0 && !isRowHighlightSelected
+            shadeAlternateRows && rowIndex % 2 === 0 && !isRowHighlightSelected && !isSubtleHighlightSelected && !isCheckboxSubtleHighlightSelected
               ? "bg-gray-50"
               : "";
           return (
             <tr
               key={rowIndex}
               className={`${cellBorderClass}${
-                selectable && selectionStyle === "ROW_HIGHLIGHT"
-                  ? " cursor-pointer"
-                  : ""
-              }${isRowHighlightSelected ? " bg-blue-50" : ""}${
-                alternateRowClass ? ` ${alternateRowClass}` : ""
-              }`}
+                isClickableRow ? " cursor-pointer" : ""
+              }${isRowHighlightSelected ? " bg-blue-500 text-white" : ""}${
+                isSubtleHighlightSelected || isCheckboxSubtleHighlightSelected ? " bg-blue-50 outline outline-1 outline-blue-500" : ""
+              }${alternateRowClass ? ` ${alternateRowClass}` : ""}`}
               onClick={
-                selectable && selectionStyle === "ROW_HIGHLIGHT"
+                isClickableRow
                   ? () => handleRowSelect(rowId)
                   : undefined
               }
             >
-              {selectable && selectionStyle === "CHECKBOX" && (
+              {selectable && (selectionStyle === "CHECKBOX" || selectionStyle === "CHECKBOX_SUBTLE_HIGHLIGHT") && (
                 <td className={`${cellPaddingClass} w-10 align-middle text-center${colDividerClass ? ` ${colDividerClass}` : ""}`}>
                   <input
                     type="checkbox"
@@ -454,10 +461,11 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
                 const bg = resolveBgColor(col.backgroundColor, row);
                 const isLastCol = colIndex === visibleColumns.length - 1;
                 const divider = !isLastCol && colDividerClass ? ` ${colDividerClass}` : "";
+                const textColorClass = isRowHighlightSelected ? "text-white" : "text-gray-900";
                 return (
                   <td
                     key={colIndex}
-                    className={`${cellPaddingClass} ${alignClass} text-sm text-gray-900${widthClass ? ` ${widthClass}` : ""}${bg.className ? ` ${bg.className}` : ""}${divider}`}
+                    className={`${cellPaddingClass} ${alignClass} text-sm ${textColorClass}${widthClass ? ` ${widthClass}` : ""}${bg.className ? ` ${bg.className}` : ""}${divider}`}
                     style={bg.style}
                   >
                     {resolveValue(col.value, row, startIndex + rowIndex)}
@@ -497,15 +505,17 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
           )}
           {totalPages > 1 && (
             <div className="flex items-center justify-end gap-2 px-3 py-2 text-sm text-gray-700">
-              <button
-                onClick={() => setCurrentPage(1)}
-                disabled={!hasPreviousPage}
-                aria-label="First page"
-                title="First page"
-                className="px-1 py-1 disabled:text-gray-400 disabled:cursor-not-allowed text-blue-700 hover:text-blue-900 cursor-pointer"
-              >
-                <ChevronsLeft size={18} />
-              </button>
+              {pagingControls === "ROW_COUNT" && totalPages >= 3 && (
+                <button
+                  onClick={() => setCurrentPage(1)}
+                  disabled={!hasPreviousPage}
+                  aria-label="First page"
+                  title="First page"
+                  className="px-1 py-1 disabled:text-gray-400 disabled:cursor-not-allowed text-blue-700 hover:text-blue-900 cursor-pointer"
+                >
+                  <ChevronsLeft size={18} />
+                </button>
+              )}
               <button
                 onClick={() => setCurrentPage(p => p - 1)}
                 disabled={!hasPreviousPage}
@@ -515,10 +525,17 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
               >
                 <ChevronLeft size={18} />
               </button>
-              <span>
-                <span className="font-bold">{startIndex + 1} – {endIndex}</span>
-                {" "}of {sortedRows.length}
-              </span>
+              {pagingControls === "ROW_COUNT" ? (
+                <span>
+                  <span className="font-bold">{startIndex + 1} – {endIndex}</span>
+                  {" "}of {sortedRows.length}
+                </span>
+              ) : (
+                <span>
+                  <span className="font-bold">{startIndex + 1} – {endIndex}</span>
+                  {" "}of many
+                </span>
+              )}
               <button
                 onClick={() => setCurrentPage(p => p + 1)}
                 disabled={!hasNextPage}
@@ -528,15 +545,17 @@ export const ReadOnlyGrid: React.FC<ReadOnlyGridProps> = ({
               >
                 <ChevronRight size={18} />
               </button>
-              <button
-                onClick={() => setCurrentPage(totalPages)}
-                disabled={!hasNextPage}
-                aria-label="Last page"
-                title="Last page"
-                className="px-1 py-1 disabled:text-gray-400 disabled:cursor-not-allowed text-blue-700 hover:text-blue-900 cursor-pointer"
-              >
-                <ChevronsRight size={18} />
-              </button>
+              {pagingControls === "ROW_COUNT" && totalPages >= 3 && (
+                <button
+                  onClick={() => setCurrentPage(totalPages)}
+                  disabled={!hasNextPage}
+                  aria-label="Last page"
+                  title="Last page"
+                  className="px-1 py-1 disabled:text-gray-400 disabled:cursor-not-allowed text-blue-700 hover:text-blue-900 cursor-pointer"
+                >
+                  <ChevronsRight size={18} />
+                </button>
+              )}
             </div>
           )}
         </>


### PR DESCRIPTION
## Summary

Brings `ReadOnlyGrid` up to Appian 26.3 parity with two new features:

1. **New `selectionStyle` values** (Closes #100)
2. **`pagingControls` prop** (Closes #101)

---

## Selection Styles (#100)

Added `"CHECKBOX_SUBTLE_HIGHLIGHT"` and `"SUBTLE_HIGHLIGHT"` to the `selectionStyle` prop, matching the exact values from Appian 26.3 docs.

| Style | Checkbox | Highlight | Click-to-select |
|-------|----------|-----------|-----------------|
| `CHECKBOX` (default) | ✅ | None | No (checkbox only) |
| `CHECKBOX_SUBTLE_HIGHLIGHT` | ✅ | Light blue bg + blue outline | Yes |
| `SUBTLE_HIGHLIGHT` | ❌ | Light blue bg + blue outline | Yes |
| `ROW_HIGHLIGHT` | ❌ | Solid blue bg + white text | Yes |

### Selection Style Screenshots

<details>
<summary>CHECKBOX (default)</summary>
<img width="2400" height="1802" alt="checkbox" src="https://github.com/user-attachments/assets/2446ac28-2837-4e7d-a661-c5783d657e95" />
</details>

<details>
<summary>CHECKBOX_SUBTLE_HIGHLIGHT (new)</summary>
<img width="2400" height="1802" alt="checkbox-subtle-highlight" src="https://github.com/user-attachments/assets/6348344b-00db-4a82-92bd-b9fe3b5523ce" />
</details>

<details>
<summary>SUBTLE_HIGHLIGHT (new)</summary>
<img width="2400" height="1802" alt="subtle-highlight" src="https://github.com/user-attachments/assets/abc59336-b53b-490f-a2cd-e6ded005b1e7" />
</details>

<details>
<summary>ROW_HIGHLIGHT (updated)</summary>
<img width="2400" height="1802" alt="row-highlight" src="https://github.com/user-attachments/assets/5abcd7cd-5834-4393-94e9-268784c302e8" />
</details>

---

## Paging Controls (#101)

Added `pagingControls` prop with values `"STANDARD"` (default) and `"ROW_COUNT"`.

| Mode | Range text | Total count | First/Last buttons |
|------|-----------|-------------|-------------------|
| `STANDARD` (default) | "1 – 5 of many" | Hidden | Hidden |
| `ROW_COUNT` | "1 – 5 of 12" | Shown | Shown (when ≥ 3 pages) |

### Paging Controls Screenshots

<details>
<summary>STANDARD paging (new default)</summary>
<img width="2400" height="1802" alt="paging-standard" src="https://github.com/user-attachments/assets/2958108d-fa58-4472-a495-289155e1507e" />
</details>

<details>
<summary>ROW_COUNT paging</summary>
<img width="2400" height="1802" alt="paging-row-count" src="https://github.com/user-attachments/assets/eaa82660-dd9c-479a-8d23-5be14733b147" />
</details>

---

## Changes

- `ReadOnlyGrid.tsx` — Implementation of both features
- `ReadOnlyGrid.stories.tsx` — New stories for all selection styles and paging modes
- `ReadOnlyGrid.test.tsx` — Updated tests for new default paging behavior

## Testing

- All 50 unit tests pass
- All 15 property-based tests pass
- TypeScript compiles cleanly