### PR TITLE
Fix lint errors (hooks order, storybook import, brace-expansion override)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist"]),
+  globalIgnores(["dist", "storybook-static"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
   "pnpm": {
     "overrides": {
       "ws": ">=8.20.1",
-      "brace-expansion": ">=5.0.6",
       "picomatch": ">=4.0.4",
       "lodash": ">=4.18.0",
       "fast-uri": ">=3.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   ws: '>=8.20.1'
-  brace-expansion: '>=5.0.6'
   picomatch: '>=4.0.4'
   lodash: '>=4.18.0'
   fast-uri: '>=3.1.2'
@@ -1710,6 +1709,9 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1721,6 +1723,12 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1775,6 +1783,9 @@ packages:
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -4610,6 +4621,8 @@ snapshots:
 
   axe-core@4.11.1: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.8: {}
@@ -4617,6 +4630,15 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -4668,6 +4690,8 @@ snapshots:
   color-name@1.1.4: {}
 
   compare-versions@6.1.1: {}
+
+  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -5247,11 +5271,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 1.1.15
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 2.1.1
 
   minimist@1.2.8: {}
 

--- a/src/components/Dropdown/DropdownFieldBase.tsx
+++ b/src/components/Dropdown/DropdownFieldBase.tsx
@@ -83,9 +83,6 @@ export const DropdownFieldBase: React.FC<DropdownFieldBaseProps> = ({
   marginBelow = "STANDARD",
   className
 }) => {
-  // Visibility control
-  if (!showWhen) return null
-
   const inputId = `dropdown-${Math.random().toString(36).substr(2, 9)}`
   const [isOpen, setIsOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -96,6 +93,31 @@ export const DropdownFieldBase: React.FC<DropdownFieldBaseProps> = ({
   const shouldShowSearch =
     searchDisplay === "ON" ||
     (searchDisplay === "AUTO" && choiceLabels.length > 11)
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+        setSearchTerm('')
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen])
+
+  // Focus search input when dropdown opens
+  useEffect(() => {
+    if (isOpen && shouldShowSearch && searchInputRef.current) {
+      searchInputRef.current.focus()
+    }
+  }, [isOpen, shouldShowSearch])
+
+  // Visibility control
+  if (!showWhen) return null
 
   // Filter choices based on search term
   const filteredChoices = searchTerm
@@ -155,28 +177,6 @@ export const DropdownFieldBase: React.FC<DropdownFieldBaseProps> = ({
       handler(null)
     }
   }
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false)
-        setSearchTerm('')
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-      return () => document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [isOpen])
-
-  // Focus search input when dropdown opens
-  useEffect(() => {
-    if (isOpen && shouldShowSearch && searchInputRef.current) {
-      searchInputRef.current.focus()
-    }
-  }, [isOpen, shouldShowSearch])
 
   // Show validations
   const showValidations = validations.length > 0

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -53,15 +53,15 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   marginBelow = "STANDARD",
   className: classNameProp
 }) => {
+  // Generate unique ID for accessibility
+  const progressId = React.useId()
+
   // Visibility control
   if (!showWhen) return null
 
   // Clamp percentage between 0 and 100 for display, but show actual value in text
   const clampedPercentage = Math.max(0, Math.min(100, percentage))
   const displayPercentage = Math.round(percentage)
-
-  // Generate unique ID for accessibility
-  const progressId = React.useId()
 
   const styleMap: Record<ProgressBarStyle, { height: string; textSize: string }> = {
     THIN: { height: 'h-2', textSize: 'text-sm' },

--- a/src/components/RichText/RichTextDisplayField.tsx
+++ b/src/components/RichText/RichTextDisplayField.tsx
@@ -54,6 +54,11 @@ export const RichTextDisplayField: React.FC<RichTextDisplayFieldProps> = ({
   marginBelow = "STANDARD",
   className: classNameProp
 }) => {
+  // Generate unique ID for accessibility
+  const fieldId = React.useMemo(() => 
+    `richtext-${Math.random().toString(36).substr(2, 9)}`, []
+  )
+
   if (!showWhen) return null
 
   // Build container classes
@@ -70,11 +75,6 @@ export const RichTextDisplayField: React.FC<RichTextDisplayFieldProps> = ({
     preventWrapping && 'truncate',
     'leading-relaxed' // Better line spacing for rich text
   ].filter(Boolean).join(' ')
-
-  // Generate unique ID for accessibility
-  const fieldId = React.useMemo(() => 
-    `richtext-${Math.random().toString(36).substr(2, 9)}`, []
-  )
 
   return (
     <div className={containerClasses}>

--- a/src/components/Tag/TagField.tsx
+++ b/src/components/Tag/TagField.tsx
@@ -60,6 +60,8 @@ export const TagField: React.FC<TagFieldProps> = ({
   marginBelow = "STANDARD",
   className
 }) => {
+  const fieldId = React.useId()
+
   // Visibility control
   if (!showWhen) return null
 
@@ -147,8 +149,6 @@ export const TagField: React.FC<TagFieldProps> = ({
       </Component>
     )
   }
-
-  const fieldId = React.useId()
 
   // Build SAIL-computed classes for root container
   const sailClasses = `${marginAboveMap[marginAbove]} ${marginBelowMap[marginBelow]}`

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -120,11 +120,11 @@ export const TextField: React.FC<TextFieldProps> = ({
   marginBelow = "STANDARD",
   className
 }) => {
-  // Visibility control
-  if (!showWhen) return null
-
   // Generate unique ID for label association
   const inputId = React.useMemo(() => `textfield-${Math.random().toString(36).substr(2, 9)}`, [])
+
+  // Visibility control
+  if (!showWhen) return null
 
   // Map inputPurpose to autocomplete attribute
   const autoCompleteMap: Record<InputPurpose, string> = {

--- a/src/stories/Welcome.stories.tsx
+++ b/src/stories/Welcome.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Welcome',


### PR DESCRIPTION
## Summary

This PR fixes all ESLint errors that were previously hidden by a broken lint setup. The root cause was a `brace-expansion` pnpm override that forced v5 globally, which crashed `minimatch@3` (used by ESLint internally) before any rules could run. Once that was resolved, 6 real errors surfaced that are fixed here.

## Changes and rationale

### 1. Remove `brace-expansion` from pnpm overrides (`package.json`)

The override `"brace-expansion": ">=5.0.6"` was added as a security patch but is too broad. It forced v5 onto `minimatch@3`, which expects v1 — the `expand` function was renamed between major versions, causing ESLint to crash with `TypeError: expand is not a function` on every run. Removing the override lets `minimatch@3` use its compatible `brace-expansion@1` as intended. The other overrides (`ws`, `picomatch`, `lodash`, `fast-uri`) are unaffected.

### 2. Add `storybook-static` to ESLint ignores (`eslint.config.js`)

The built Storybook output in `storybook-static/` was being linted, producing ~80 spurious warnings and errors against minified output that we don't own. Added it alongside the existing `dist` ignore.

### 3. Fix `react-hooks/rules-of-hooks` violations (5 files)

**Affected files:** `ProgressBar.tsx`, `RichTextDisplayField.tsx`, `TagField.tsx`, `TextField.tsx`, `DropdownFieldBase.tsx`


**The fix:** Moved all hook calls to before the early return in each component. The logic and rendered output are identical — only the ordering of declarations changed.

**User-facing impact:** None in the happy path. The previous code would actually cause React to throw a runtime error if a component transitioned from `showWhen={true}` to `showWhen={false}` and back, because the hook call count would change between renders. The fix makes that transition safe.

### 4. Fix `storybook/no-renderer-packages` violation (`Welcome.stories.tsx`)

Changed `import type { Meta, StoryObj } from '@storybook/react'` to `@storybook/react-vite`, matching every other stories file in the project. No functional change — these are type-only imports.

## Testing

- **Unit tests:** 163/163 passing (`pnpm run test:unit`)
- **Lint:** 0 errors, 82 warnings (all pre-existing `no-unused-vars` warnings, not introduced by this PR)
- **Type check:** `tsc --noEmit` passes clean