### PR TITLE
feat: add AgentSteps component

### DIFF
--- a/src/components/Chat/AgentSteps.stories.tsx
+++ b/src/components/Chat/AgentSteps.stories.tsx
@@ -15,27 +15,23 @@ type Story = StoryObj<typeof meta>
 const basicSteps: AgentStep[] = [
   {
     id: '1',
-    icon: 'file',
     title: 'Reading project configuration',
     subtitle: 'package.json, tsconfig.json',
     status: 'COMPLETED',
   },
   {
     id: '2',
-    icon: 'database',
     title: 'Analyzing component structure',
     subtitle: 'Identified 12 components across 3 directories',
     status: 'COMPLETED',
   },
   {
     id: '3',
-    icon: 'gitBranch',
     title: 'Creating feature branch',
     status: 'ACTIVE',
   },
   {
     id: '4',
-    icon: 'plus',
     title: 'Generate new component files',
     status: 'PENDING',
   },
@@ -47,12 +43,22 @@ export const Default: Story = {
   },
 }
 
+export const AllStatuses: Story = {
+  args: {
+    steps: [
+      { id: '1', title: 'Completed step', subtitle: 'Finished successfully', status: 'COMPLETED' },
+      { id: '2', title: 'Active step', subtitle: 'Currently processing...', status: 'ACTIVE' },
+      { id: '3', title: 'Pending step', subtitle: 'Waiting to start', status: 'PENDING' },
+      { id: '4', title: 'Error step', subtitle: 'Build failed with 3 errors', status: 'ERROR' },
+    ],
+  },
+}
+
 export const WithCodePreview: Story = {
   args: {
     steps: [
       {
         id: '1',
-        icon: 'file',
         title: 'Created AgentSteps.tsx',
         subtitle: 'New component with timeline layout',
         status: 'COMPLETED',
@@ -69,7 +75,6 @@ export const WithCodePreview: Story = {
       },
       {
         id: '2',
-        icon: 'file',
         title: 'Updated Chat/index.ts',
         subtitle: 'Added barrel export',
         status: 'COMPLETED',
@@ -88,7 +93,6 @@ export const WithActions: Story = {
     steps: [
       {
         id: '1',
-        icon: 'file',
         title: 'Modified ButtonWidget.tsx',
         subtitle: 'Added loading state support',
         status: 'COMPLETED',
@@ -98,7 +102,6 @@ export const WithActions: Story = {
       },
       {
         id: '2',
-        icon: 'file',
         title: 'Modified TagField.tsx',
         subtitle: 'Updated color resolution logic',
         status: 'COMPLETED',
@@ -115,12 +118,23 @@ export const WithActions: Story = {
   },
 }
 
+export const WithError: Story = {
+  args: {
+    steps: [
+      { id: '1', title: 'Read existing components', status: 'COMPLETED' },
+      { id: '2', title: 'Generated migration script', status: 'COMPLETED' },
+      { id: '3', title: 'Running database migration', subtitle: 'Connection refused: ECONNREFUSED 127.0.0.1:5432', status: 'ERROR' },
+      { id: '4', title: 'Verify migration results', status: 'PENDING' },
+    ],
+  },
+}
+
 export const AllCompleted: Story = {
   args: {
     steps: [
-      { id: '1', icon: 'file', title: 'Read existing components', status: 'COMPLETED' },
-      { id: '2', icon: 'database', title: 'Analyzed dependencies', status: 'COMPLETED' },
-      { id: '3', icon: 'plus', title: 'Created new component', status: 'COMPLETED' },
+      { id: '1', title: 'Read existing components', status: 'COMPLETED' },
+      { id: '2', title: 'Analyzed dependencies', status: 'COMPLETED' },
+      { id: '3', title: 'Created new component', status: 'COMPLETED' },
       { id: '4', title: 'Verified build passes', status: 'COMPLETED' },
     ],
   },
@@ -130,5 +144,12 @@ export const SmallSize: Story = {
   args: {
     steps: basicSteps,
     size: 'SMALL',
+  },
+}
+
+export const LargeSize: Story = {
+  args: {
+    steps: basicSteps,
+    size: 'LARGE',
   },
 }

--- a/src/components/Chat/AgentSteps.stories.tsx
+++ b/src/components/Chat/AgentSteps.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { AgentSteps } from './AgentSteps'
+import type { AgentStep } from './AgentSteps'
+
+const meta = {
+  title: 'Components/Chat/AgentSteps',
+  component: AgentSteps,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof AgentSteps>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const basicSteps: AgentStep[] = [
+  {
+    id: '1',
+    icon: 'file',
+    title: 'Reading project configuration',
+    subtitle: 'package.json, tsconfig.json',
+    status: 'COMPLETED',
+  },
+  {
+    id: '2',
+    icon: 'database',
+    title: 'Analyzing component structure',
+    subtitle: 'Identified 12 components across 3 directories',
+    status: 'COMPLETED',
+  },
+  {
+    id: '3',
+    icon: 'gitBranch',
+    title: 'Creating feature branch',
+    status: 'ACTIVE',
+  },
+  {
+    id: '4',
+    icon: 'plus',
+    title: 'Generate new component files',
+    status: 'PENDING',
+  },
+]
+
+export const Default: Story = {
+  args: {
+    steps: basicSteps,
+  },
+}
+
+export const WithCodePreview: Story = {
+  args: {
+    steps: [
+      {
+        id: '1',
+        icon: 'file',
+        title: 'Created AgentSteps.tsx',
+        subtitle: 'New component with timeline layout',
+        status: 'COMPLETED',
+        preview: {
+          type: 'code',
+          content: `export const AgentSteps: React.FC<AgentStepsProps> = ({
+  steps,
+  size = "STANDARD",
+  className,
+}) => {
+  // ...
+}`,
+        },
+      },
+      {
+        id: '2',
+        icon: 'file',
+        title: 'Updated Chat/index.ts',
+        subtitle: 'Added barrel export',
+        status: 'COMPLETED',
+      },
+      {
+        id: '3',
+        title: 'Running type check',
+        status: 'ACTIVE',
+      },
+    ],
+  },
+}
+
+export const WithActions: Story = {
+  args: {
+    steps: [
+      {
+        id: '1',
+        icon: 'file',
+        title: 'Modified ButtonWidget.tsx',
+        subtitle: 'Added loading state support',
+        status: 'COMPLETED',
+        actions: [
+          { label: 'Revert', icon: 'rotateCcw', style: 'GHOST' },
+        ],
+      },
+      {
+        id: '2',
+        icon: 'file',
+        title: 'Modified TagField.tsx',
+        subtitle: 'Updated color resolution logic',
+        status: 'COMPLETED',
+        actions: [
+          { label: 'Revert', icon: 'rotateCcw', style: 'GHOST' },
+        ],
+      },
+      {
+        id: '3',
+        title: 'Waiting for confirmation',
+        status: 'PENDING',
+      },
+    ],
+  },
+}
+
+export const AllCompleted: Story = {
+  args: {
+    steps: [
+      { id: '1', icon: 'file', title: 'Read existing components', status: 'COMPLETED' },
+      { id: '2', icon: 'database', title: 'Analyzed dependencies', status: 'COMPLETED' },
+      { id: '3', icon: 'plus', title: 'Created new component', status: 'COMPLETED' },
+      { id: '4', title: 'Verified build passes', status: 'COMPLETED' },
+    ],
+  },
+}
+
+export const SmallSize: Story = {
+  args: {
+    steps: basicSteps,
+    size: 'SMALL',
+  },
+}

--- a/src/components/Chat/AgentSteps.tsx
+++ b/src/components/Chat/AgentSteps.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { CheckCircle, Circle, XCircle, FileText, Database, Plus, LoaderCircle, GitBranch, RotateCcw } from 'lucide-react'
 import { mergeClasses } from '../../utils/classNames'
 import { ButtonWidget } from '../Button/ButtonWidget'
+import { TextItem } from '../RichText/TextItem'
 
 const iconMap = {
   circle: Circle,
@@ -93,10 +94,10 @@ interface AgentStepItemProps {
   size: AgentStepsSize
 }
 
-const sizeConfig: Record<AgentStepsSize, { text: string; subtitle: string; iconSize: string; iconMt: string; lineTop: string }> = {
-  SMALL: { text: 'text-xs leading-4', subtitle: 'text-xs', iconSize: 'size-3.5', iconMt: 'mt-0.5', lineTop: 'top-4' },
-  STANDARD: { text: 'text-sm leading-5', subtitle: 'text-xs', iconSize: 'size-4', iconMt: 'mt-0.5', lineTop: 'top-5' },
-  LARGE: { text: 'text-lg leading-7', subtitle: 'text-sm', iconSize: 'size-5', iconMt: 'mt-1', lineTop: 'top-7' },
+const sizeConfig: Record<AgentStepsSize, { titleSize: 'SMALL' | 'STANDARD' | 'MEDIUM'; subtitleSize: 'SMALL' | 'STANDARD'; iconSize: string; iconMt: string; lineTop: string }> = {
+  SMALL: { titleSize: 'SMALL', subtitleSize: 'SMALL', iconSize: 'size-3.5', iconMt: 'mt-0.5', lineTop: 'top-4' },
+  STANDARD: { titleSize: 'STANDARD', subtitleSize: 'SMALL', iconSize: 'size-4', iconMt: 'mt-0.5', lineTop: 'top-5' },
+  LARGE: { titleSize: 'MEDIUM', subtitleSize: 'STANDARD', iconSize: 'size-5', iconMt: 'mt-1', lineTop: 'top-7' },
 }
 
 const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, size }) => {
@@ -140,15 +141,15 @@ const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, size }) => 
       </div>
 
       {/* Content — negative margin for optical alignment with icon */}
-      <div className="relative flex-1 min-w-0 -mt-[0.2rem]">
-        <span className={`font-medium text-gray-900 ${config.text}`}>
-          {step.title}
-        </span>
+      <div className="relative flex-1 min-w-0 -mt-[0.1rem]">
+        <div className="leading-none">
+          <TextItem text={step.title} style="PLAIN" size={config.titleSize} color="STANDARD" />
+        </div>
 
         {step.subtitle && (
-          <p className={`mt-0.5 text-gray-700 ${config.subtitle} leading-relaxed`}>
-            {step.subtitle}
-          </p>
+          <div className="leading-normal">
+            <TextItem text={step.subtitle} size={config.subtitleSize} color="SECONDARY" />
+          </div>
         )}
 
         {step.actions && step.actions.length > 0 && (

--- a/src/components/Chat/AgentSteps.tsx
+++ b/src/components/Chat/AgentSteps.tsx
@@ -35,7 +35,7 @@ export interface AgentStepAction {
 export interface AgentStep {
   /** Unique identifier for the step */
   id: string
-  /** Lucide icon key to display (overrides default status icon) */
+  /** Lucide icon key to display (used when status is PENDING; other statuses use fixed status icons) */
   icon?: keyof typeof iconMap
   /** Step title text */
   title: string
@@ -138,6 +138,7 @@ const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, size }) => 
       {/* Icon */}
       <div className={`relative z-10 flex items-center justify-center ${config.iconSize} ${config.iconMt} shrink-0 bg-white`}>
         {renderIcon()}
+        <span className="sr-only">{statusLabel(step.status)}</span>
       </div>
 
       {/* Content — negative margin for optical alignment with icon */}
@@ -205,4 +206,17 @@ function mapIconToLucideName(key: keyof typeof iconMap): string {
     rotateCcw: 'rotate-ccw',
   }
   return nameMap[key]
+}
+
+/**
+ * Returns a human-readable status label for screen readers.
+ */
+function statusLabel(status: AgentStepStatus): string {
+  const labels: Record<AgentStepStatus, string> = {
+    COMPLETED: 'Completed',
+    ACTIVE: 'In progress',
+    PENDING: 'Pending',
+    ERROR: 'Error',
+  }
+  return labels[status]
 }

--- a/src/components/Chat/AgentSteps.tsx
+++ b/src/components/Chat/AgentSteps.tsx
@@ -140,33 +140,31 @@ const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, size }) => 
       </div>
 
       {/* Content */}
-      <div className="flex-1 min-w-0">
-        <div className="flex items-baseline justify-between gap-2">
-          <span className={`font-medium text-gray-900 ${config.text}`}>
-            {step.title}
-          </span>
-
-          {step.actions && step.actions.length > 0 && (
-            <div className="flex items-center gap-1 shrink-0">
-              {step.actions.map((action, idx) => (
-                <ButtonWidget
-                  key={idx}
-                  label={action.label}
-                  icon={action.icon ? mapIconToLucideName(action.icon) : undefined}
-                  style={action.style || "GHOST"}
-                  color="SECONDARY"
-                  size="SMALL"
-                  onClick={action.onClick}
-                />
-              ))}
-            </div>
-          )}
-        </div>
+      <div className="relative flex-1 min-w-0">
+        <span className={`font-medium text-gray-900 ${config.text}`}>
+          {step.title}
+        </span>
 
         {step.subtitle && (
           <p className={`mt-0.5 text-gray-700 ${config.subtitle} leading-relaxed`}>
             {step.subtitle}
           </p>
+        )}
+
+        {step.actions && step.actions.length > 0 && (
+          <div className="absolute top-0 right-0 flex items-center gap-1">
+            {step.actions.map((action, idx) => (
+              <ButtonWidget
+                key={idx}
+                label={action.label}
+                icon={action.icon ? mapIconToLucideName(action.icon) : undefined}
+                style={action.style || "GHOST"}
+                color="SECONDARY"
+                size="SMALL"
+                onClick={action.onClick}
+              />
+            ))}
+          </div>
         )}
 
         {step.preview && step.preview.type === "code" && (

--- a/src/components/Chat/AgentSteps.tsx
+++ b/src/components/Chat/AgentSteps.tsx
@@ -139,8 +139,8 @@ const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, size }) => 
         {renderIcon()}
       </div>
 
-      {/* Content */}
-      <div className="relative flex-1 min-w-0">
+      {/* Content — negative margin for optical alignment with icon */}
+      <div className="relative flex-1 min-w-0 -mt-[0.2rem]">
         <span className={`font-medium text-gray-900 ${config.text}`}>
           {step.title}
         </span>

--- a/src/components/Chat/AgentSteps.tsx
+++ b/src/components/Chat/AgentSteps.tsx
@@ -1,0 +1,202 @@
+import * as React from 'react'
+import { CheckCircle, Circle, FileText, Database, Plus, LoaderCircle, GitBranch, RotateCcw } from 'lucide-react'
+import { mergeClasses } from '../../utils/classNames'
+import { ButtonWidget } from '../Button/ButtonWidget'
+import type { SAILSize } from '../../types/sail'
+
+const iconMap = {
+  circle: Circle,
+  file: FileText,
+  database: Database,
+  plus: Plus,
+  loaderCircle: LoaderCircle,
+  gitBranch: GitBranch,
+  rotateCcw: RotateCcw,
+} as const
+
+type AgentStepStatus = "COMPLETED" | "ACTIVE" | "PENDING"
+
+type AgentStepActionStyle = "SOLID" | "OUTLINE" | "GHOST" | "LINK"
+
+export interface AgentStepAction {
+  /** Button label */
+  label: string
+  /** Lucide icon key */
+  icon?: keyof typeof iconMap
+  /** Button style */
+  style?: AgentStepActionStyle
+  /** Click handler */
+  onClick?: () => void
+}
+
+export interface AgentStep {
+  /** Unique identifier for the step */
+  id: string
+  /** Lucide icon key to display */
+  icon?: keyof typeof iconMap
+  /** Step title text */
+  title: string
+  /** Optional subtitle/description */
+  subtitle?: string
+  /** Optional code preview block */
+  preview?: {
+    type: "code"
+    content: string
+  }
+  /** Optional action buttons */
+  actions?: AgentStepAction[]
+  /** Step status */
+  status: AgentStepStatus
+}
+
+export interface AgentStepsProps {
+  /** Array of steps to display */
+  steps: AgentStep[]
+  /** Size of step text */
+  size?: SAILSize
+  /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
+  className?: string
+}
+
+/**
+ * AgentSteps Component
+ * Displays a vertical timeline of agent execution steps with status indicators.
+ * Used within chat interfaces to show AI agent progress.
+ */
+export const AgentSteps: React.FC<AgentStepsProps> = ({
+  steps,
+  size = "STANDARD",
+  className,
+}) => {
+  const textSizeMap: Record<SAILSize, string> = {
+    SMALL: 'text-xs',
+    STANDARD: 'text-sm',
+    MEDIUM: 'text-base',
+    LARGE: 'text-lg',
+  }
+
+  const sailClasses = 'relative'
+  const finalClasses = mergeClasses(sailClasses, className)
+
+  return (
+    <div className={finalClasses} role="list" aria-label="Agent steps">
+      {steps.map((step, index) => (
+        <AgentStepItem
+          key={step.id}
+          step={step}
+          isLast={index === steps.length - 1}
+          textSize={textSizeMap[size]}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface AgentStepItemProps {
+  step: AgentStep
+  isLast: boolean
+  textSize: string
+}
+
+const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, textSize }) => {
+  const statusColorMap: Record<AgentStepStatus, string> = {
+    COMPLETED: 'text-blue-500',
+    ACTIVE: 'text-gray-500',
+    PENDING: 'text-gray-500',
+  }
+
+  const renderIcon = () => {
+    if (step.status === "COMPLETED") {
+      return <CheckCircle className="size-4 text-blue-500" aria-hidden="true" />
+    }
+
+    if (step.icon) {
+      const IconComponent = iconMap[step.icon]
+      return <IconComponent className={`size-4 ${statusColorMap[step.status]}`} aria-hidden="true" />
+    }
+
+    return <Circle className="size-4 text-gray-500" aria-hidden="true" />
+  }
+
+  return (
+    <div className="relative flex items-start gap-3 pb-6" role="listitem">
+      {/* Connector line */}
+      {!isLast && (
+        <div
+          className="absolute left-[7px] top-5 bottom-0 w-0.5 bg-gray-200"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Icon */}
+      <div className="relative z-10 flex items-center justify-center size-4 mt-0.5 shrink-0 bg-white">
+        {renderIcon()}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-2">
+          <span className={`font-medium text-gray-900 ${textSize}`}>
+            {step.title}
+          </span>
+
+          {step.actions && step.actions.length > 0 && (
+            <div className="flex items-center gap-1 shrink-0">
+              {step.actions.map((action, idx) => (
+                <ButtonWidget
+                  key={idx}
+                  label={action.label}
+                  icon={action.icon ? mapIconToLucideName(action.icon) : undefined}
+                  style={action.style || "GHOST"}
+                  color="SECONDARY"
+                  size="SMALL"
+                  onClick={action.onClick}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {step.subtitle && (
+          <p className="mt-0.5 text-xs text-gray-500 leading-relaxed">
+            {step.subtitle}
+          </p>
+        )}
+
+        {step.preview && step.preview.type === "code" && (
+          <AgentStepPreview content={step.preview.content} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface AgentStepPreviewProps {
+  content: string
+}
+
+const AgentStepPreview: React.FC<AgentStepPreviewProps> = ({ content }) => {
+  return (
+    <div className="mt-2 rounded-sm border border-gray-200 bg-gray-50 p-3 font-mono text-xs leading-relaxed">
+      <pre className="overflow-x-auto whitespace-pre-wrap break-all text-gray-700">
+        {content}
+      </pre>
+    </div>
+  )
+}
+
+/**
+ * Maps internal icon keys to Lucide kebab-case names for ButtonWidget
+ */
+function mapIconToLucideName(key: keyof typeof iconMap): string {
+  const nameMap: Record<keyof typeof iconMap, string> = {
+    circle: 'circle',
+    file: 'file-text',
+    database: 'database',
+    plus: 'plus',
+    loaderCircle: 'loader-circle',
+    gitBranch: 'git-branch',
+    rotateCcw: 'rotate-ccw',
+  }
+  return nameMap[key]
+}

--- a/src/components/Chat/AgentSteps.tsx
+++ b/src/components/Chat/AgentSteps.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { CheckCircle, Circle, FileText, Database, Plus, LoaderCircle, GitBranch, RotateCcw } from 'lucide-react'
+import { CheckCircle, Circle, XCircle, FileText, Database, Plus, LoaderCircle, GitBranch, RotateCcw } from 'lucide-react'
 import { mergeClasses } from '../../utils/classNames'
 import { ButtonWidget } from '../Button/ButtonWidget'
-import type { SAILSize } from '../../types/sail'
 
 const iconMap = {
   circle: Circle,
+  xCircle: XCircle,
   file: FileText,
   database: Database,
   plus: Plus,
@@ -14,9 +14,11 @@ const iconMap = {
   rotateCcw: RotateCcw,
 } as const
 
-type AgentStepStatus = "COMPLETED" | "ACTIVE" | "PENDING"
+type AgentStepStatus = "COMPLETED" | "ACTIVE" | "PENDING" | "ERROR"
 
 type AgentStepActionStyle = "SOLID" | "OUTLINE" | "GHOST" | "LINK"
+
+type AgentStepsSize = "SMALL" | "STANDARD" | "LARGE"
 
 export interface AgentStepAction {
   /** Button label */
@@ -32,7 +34,7 @@ export interface AgentStepAction {
 export interface AgentStep {
   /** Unique identifier for the step */
   id: string
-  /** Lucide icon key to display */
+  /** Lucide icon key to display (overrides default status icon) */
   icon?: keyof typeof iconMap
   /** Step title text */
   title: string
@@ -52,8 +54,8 @@ export interface AgentStep {
 export interface AgentStepsProps {
   /** Array of steps to display */
   steps: AgentStep[]
-  /** Size of step text */
-  size?: SAILSize
+  /** Size of step text: SMALL (12px), STANDARD (14px), LARGE (18px) */
+  size?: AgentStepsSize
   /** Additional Tailwind classes for prototype-specific styling (not part of SAIL API) */
   className?: string
 }
@@ -68,13 +70,6 @@ export const AgentSteps: React.FC<AgentStepsProps> = ({
   size = "STANDARD",
   className,
 }) => {
-  const textSizeMap: Record<SAILSize, string> = {
-    SMALL: 'text-xs',
-    STANDARD: 'text-sm',
-    MEDIUM: 'text-base',
-    LARGE: 'text-lg',
-  }
-
   const sailClasses = 'relative'
   const finalClasses = mergeClasses(sailClasses, className)
 
@@ -85,7 +80,7 @@ export const AgentSteps: React.FC<AgentStepsProps> = ({
           key={step.id}
           step={step}
           isLast={index === steps.length - 1}
-          textSize={textSizeMap[size]}
+          size={size}
         />
       ))}
     </div>
@@ -95,27 +90,38 @@ export const AgentSteps: React.FC<AgentStepsProps> = ({
 interface AgentStepItemProps {
   step: AgentStep
   isLast: boolean
-  textSize: string
+  size: AgentStepsSize
 }
 
-const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, textSize }) => {
-  const statusColorMap: Record<AgentStepStatus, string> = {
-    COMPLETED: 'text-blue-500',
-    ACTIVE: 'text-gray-500',
-    PENDING: 'text-gray-500',
-  }
+const sizeConfig: Record<AgentStepsSize, { text: string; subtitle: string; iconSize: string; iconMt: string; lineTop: string }> = {
+  SMALL: { text: 'text-xs leading-4', subtitle: 'text-xs', iconSize: 'size-3.5', iconMt: 'mt-0.5', lineTop: 'top-4' },
+  STANDARD: { text: 'text-sm leading-5', subtitle: 'text-xs', iconSize: 'size-4', iconMt: 'mt-0.5', lineTop: 'top-5' },
+  LARGE: { text: 'text-lg leading-7', subtitle: 'text-sm', iconSize: 'size-5', iconMt: 'mt-1', lineTop: 'top-7' },
+}
+
+const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, size }) => {
+  const config = sizeConfig[size]
 
   const renderIcon = () => {
     if (step.status === "COMPLETED") {
-      return <CheckCircle className="size-4 text-blue-500" aria-hidden="true" />
+      return <CheckCircle className={`${config.iconSize} text-blue-500`} aria-hidden="true" />
     }
 
+    if (step.status === "ERROR") {
+      return <XCircle className={`${config.iconSize} text-red-700`} aria-hidden="true" />
+    }
+
+    if (step.status === "ACTIVE") {
+      return <LoaderCircle className={`${config.iconSize} text-blue-500 animate-spin`} aria-hidden="true" />
+    }
+
+    // PENDING — use custom icon if provided, otherwise default circle
     if (step.icon) {
       const IconComponent = iconMap[step.icon]
-      return <IconComponent className={`size-4 ${statusColorMap[step.status]}`} aria-hidden="true" />
+      return <IconComponent className={`${config.iconSize} text-gray-500`} aria-hidden="true" />
     }
 
-    return <Circle className="size-4 text-gray-500" aria-hidden="true" />
+    return <Circle className={`${config.iconSize} text-gray-500`} aria-hidden="true" />
   }
 
   return (
@@ -123,20 +129,20 @@ const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, textSize })
       {/* Connector line */}
       {!isLast && (
         <div
-          className="absolute left-[7px] top-5 bottom-0 w-0.5 bg-gray-200"
+          className={`absolute left-[7px] ${config.lineTop} bottom-0 w-0.5 bg-gray-200`}
           aria-hidden="true"
         />
       )}
 
       {/* Icon */}
-      <div className="relative z-10 flex items-center justify-center size-4 mt-0.5 shrink-0 bg-white">
+      <div className={`relative z-10 flex items-center justify-center ${config.iconSize} ${config.iconMt} shrink-0 bg-white`}>
         {renderIcon()}
       </div>
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-start justify-between gap-2">
-          <span className={`font-medium text-gray-900 ${textSize}`}>
+        <div className="flex items-baseline justify-between gap-2">
+          <span className={`font-medium text-gray-900 ${config.text}`}>
             {step.title}
           </span>
 
@@ -158,7 +164,7 @@ const AgentStepItem: React.FC<AgentStepItemProps> = ({ step, isLast, textSize })
         </div>
 
         {step.subtitle && (
-          <p className="mt-0.5 text-xs text-gray-500 leading-relaxed">
+          <p className={`mt-0.5 text-gray-700 ${config.subtitle} leading-relaxed`}>
             {step.subtitle}
           </p>
         )}
@@ -191,6 +197,7 @@ const AgentStepPreview: React.FC<AgentStepPreviewProps> = ({ content }) => {
 function mapIconToLucideName(key: keyof typeof iconMap): string {
   const nameMap: Record<keyof typeof iconMap, string> = {
     circle: 'circle',
+    xCircle: 'x-circle',
     file: 'file-text',
     database: 'database',
     plus: 'plus',

--- a/src/components/Chat/index.ts
+++ b/src/components/Chat/index.ts
@@ -18,3 +18,6 @@ export type { ChatUserMessageProps } from './ChatUserMessage'
 
 export { ChatAssistantMessage } from './ChatAssistantMessage'
 export type { ChatAssistantMessageProps } from './ChatAssistantMessage'
+
+export { AgentSteps } from './AgentSteps'
+export type { AgentStepsProps, AgentStep, AgentStepAction } from './AgentSteps'


### PR DESCRIPTION
## Summary

Ports the AgentSteps component from Propeller to Sailwind, adapted to Sailwind conventions.

## Changes

- **New component:** `AgentSteps` — displays a vertical timeline of agent execution steps with status indicators, designed for use within chat interfaces
- **Stories:** Multiple Storybook stories covering default, code preview, actions, all-completed, and small size variants
- **Export:** Added to Chat barrel export

## Sailwind adaptations from Propeller

| Propeller | Sailwind |
|-----------|----------|
| `cn()` utility | `mergeClasses()` |
| shadcn Item/ItemGroup composition | Flat div structure with Tailwind |
| shadcn `Button` | `ButtonWidget` (SAIL API) |
| lowercase status (`completed`) | UPPERCASE SAIL values (`COMPLETED`) |
| `@/` path aliases | Relative imports |
| shadcn semantic tokens | Aurora palette colors |

## Testing

- `pnpm run build:lib` — passes (component emitted at `dist/components/Chat/AgentSteps.js`)
- `pnpm run lint` — no new warnings