### PR TITLE
Add $schema reference to tokens.json

### DIFF
--- a/public/tokens.json
+++ b/public/tokens.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "color": {
     "red": {
       "50": {


### PR DESCRIPTION
Adds the official DTCG Format Module 2025.10 JSON Schema reference to `public/tokens.json`.

This enables:
- VS Code autocomplete and validation against the spec
- Clear documentation of which DTCG version the file conforms to
- Editor-level error detection for invalid token structures

One-line addition, no behavior change.

Closes #154